### PR TITLE
feat(mpe): add MaaPipelineEditor support and related commands

### DIFF
--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -130,7 +130,8 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
-- MPE iframe 使用 v1.2.0 握手协议；外部链接由宿主校验后交给 VS Code 打开
+- MPE 加载后若源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
+- MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择
 - MPE 地址可通过 `maa.pipelineEditorUrl` 配置，生产地址要求 HTTPS，本机 localhost 开发地址允许 HTTP
 
 该面板是外部编辑器集成，不改变普通 Pipeline 编辑器、命令和菜单的既有行为。

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -122,6 +122,19 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 
 > 注意：MaaAssistantArknights 的 pipeline JSON 语法与 MaaFramework V2 存在差异，插件对此的支持有限。
 
+### 11. 外部工具集成：MaaPipelineEditor
+
+对 MaaFramework Pipeline JSON/JSONC 文件提供可编辑的 MaaPipelineEditor（MPE）嵌入面板：
+
+- 可从文件树、编辑器正文、编辑器标题栏或命令面板打开
+- 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
+- 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
+- MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
+- MPE iframe 使用 v1.2.0 握手协议；外部链接由宿主校验后交给 VS Code 打开
+- MPE 地址可通过 `maa.pipelineEditorUrl` 配置，生产地址要求 HTTPS，本机 localhost 开发地址允许 HTTP
+
+该面板是外部编辑器集成，不改变普通 Pipeline 编辑器、命令和菜单的既有行为。
+
 ## MAA 日志与存储目录
 
 MaaFramework 原生日志（`maafw.log` / `maa.log`）和识别绘图默认写入当前活动 interface 项目的 `debug/`。`maatools.config.mts` 中的 `cwd`、`maaLogDir` 可覆盖该目录；没有活动项目或项目目录不可写时回退到 `context.storageUri/debug/`（无工作区时再回退到 `context.globalStorageUri/debug/`）。插件自身日志和上传图片副本仍保存在 VS Code storage，Native 模块与跨窗口协调文件仍保存在 global storage。

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,6 +29,7 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
+    ├── mpe.ts                # MPE iframe 面板、握手、同步与保存桥接
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排

--- a/pkgs/extension/package.json
+++ b/pkgs/extension/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "lint": "tsc -p . --noEmit",
-    "test": "node --test test/evalIssues.test.ts test/serviceArchitecture.test.ts"
+    "test": "node --test test/evalIssues.test.ts test/mpe.test.ts test/serviceArchitecture.test.ts"
   },
   "devDependencies": {
     "@jimp/core": "^1.6.0",

--- a/pkgs/extension/src/command.ts
+++ b/pkgs/extension/src/command.ts
@@ -24,6 +24,8 @@ export const commands = {
 
   DebugQueryLocation: 'maa.debug.query-location',
 
+  OpenMpe: 'maa.open-mpe',
+
   FindTaskRef: 'maa.private.find-task-ref',
   TriggerCompletion: 'maa.private.trigger-completion',
   LocaleExtract: 'maa.private.locale-extract'

--- a/pkgs/extension/src/service/command.ts
+++ b/pkgs/extension/src/service/command.ts
@@ -18,6 +18,7 @@ import { autoConvertRangeLocation, convertRange } from './language/utils'
 import {
   interfaceService,
   launchService,
+  mpeService,
   rootService,
   serverService,
   shortcutService,
@@ -134,6 +135,11 @@ export class CommandService extends BaseService {
         }
       }
     )
+
+    this.defer = vscode.commands.registerCommand(commands.OpenMpe, async (uri?: vscode.Uri) => {
+      const target = uri ?? vscode.window.activeTextEditor?.document.uri
+      return target ? mpeService.open(target) : false
+    })
 
     this.defer = vscode.commands.registerCommand(commands.GotoTask, async (task?: string) => {
       await interfaceService.interfaceBundle?.flush()

--- a/pkgs/extension/src/service/index.ts
+++ b/pkgs/extension/src/service/index.ts
@@ -27,7 +27,7 @@ import { PipelineWorkspaceSymbolProvider } from './language/pipeline/workspaceSy
 import { LaunchService } from './launch'
 import { MpeService } from './mpe'
 import { NativeService } from './native'
-import { registerServices } from './registry'
+import { type ServiceRegistry, registerServices } from './registry'
 import { RootService } from './root'
 import { ServerService } from './server'
 import { ShortcutService } from './shortcut'
@@ -44,6 +44,7 @@ export {
   interfaceService,
   launchService,
   nativeService,
+  mpeService,
   rootService,
   serverService,
   shortcutService,
@@ -59,28 +60,26 @@ export let webviewControlService: WebviewControlService
 export async function init(ctx: vscode.ExtensionContext) {
   initContext(ctx)
 
-  const services = {} as import('./registry').ServiceRegistry
-  const publish = <K extends keyof import('./registry').ServiceRegistry>(
-    name: K,
-    service: import('./registry').ServiceRegistry[K]
-  ) => {
-    services[name] = service
+  const publish = <K extends keyof ServiceRegistry>(name: K, service: ServiceRegistry[K]) => {
     registerServices({ [name]: service })
+    return service
   }
 
-  publish('stateService', new StateService())
-  publish('nativeService', new NativeService())
-  publish('statusBarService', new StatusBarService())
-  publish('serverService', new ServerService())
-  publish('shortcutService', new ShortcutService())
-  publish('rootService', new RootService())
-  publish('diagnosticService', new DiagnosticService())
-  publish('interfaceService', new InterfaceService())
-  publish('launchService', new LaunchService())
-  publish('debugService', new DebugService())
-  publish('commandService', new CommandService())
-  publish('agentService', new AgentService())
-  publish('mpeService', new MpeService())
+  const services = {
+    stateService: publish('stateService', new StateService()),
+    nativeService: publish('nativeService', new NativeService()),
+    statusBarService: publish('statusBarService', new StatusBarService()),
+    serverService: publish('serverService', new ServerService()),
+    shortcutService: publish('shortcutService', new ShortcutService()),
+    rootService: publish('rootService', new RootService()),
+    diagnosticService: publish('diagnosticService', new DiagnosticService()),
+    interfaceService: publish('interfaceService', new InterfaceService()),
+    launchService: publish('launchService', new LaunchService()),
+    debugService: publish('debugService', new DebugService()),
+    commandService: publish('commandService', new CommandService()),
+    agentService: publish('agentService', new AgentService()),
+    mpeService: publish('mpeService', new MpeService())
+  } satisfies ServiceRegistry
 
   pipelineLanguageServices = [
     new PipelineCodeLensProvider(),

--- a/pkgs/extension/src/service/index.ts
+++ b/pkgs/extension/src/service/index.ts
@@ -25,6 +25,7 @@ import { PipelineInlayHintsProvider } from './language/pipeline/inlayHint'
 import { PipelineReferenceProvider } from './language/pipeline/reference'
 import { PipelineWorkspaceSymbolProvider } from './language/pipeline/workspaceSymbol'
 import { LaunchService } from './launch'
+import { MpeService } from './mpe'
 import { NativeService } from './native'
 import { registerServices } from './registry'
 import { RootService } from './root'
@@ -58,21 +59,28 @@ export let webviewControlService: WebviewControlService
 export async function init(ctx: vscode.ExtensionContext) {
   initContext(ctx)
 
-  const services = {
-    stateService: new StateService(),
-    nativeService: new NativeService(),
-    serverService: new ServerService(),
-    shortcutService: new ShortcutService(),
-    rootService: new RootService(),
-    interfaceService: new InterfaceService(),
-    launchService: new LaunchService(),
-    debugService: new DebugService(),
-    commandService: new CommandService(),
-    diagnosticService: new DiagnosticService(),
-    statusBarService: new StatusBarService(),
-    agentService: new AgentService()
+  const services = {} as import('./registry').ServiceRegistry
+  const publish = <K extends keyof import('./registry').ServiceRegistry>(
+    name: K,
+    service: import('./registry').ServiceRegistry[K]
+  ) => {
+    services[name] = service
+    registerServices({ [name]: service })
   }
-  registerServices(services)
+
+  publish('stateService', new StateService())
+  publish('nativeService', new NativeService())
+  publish('statusBarService', new StatusBarService())
+  publish('serverService', new ServerService())
+  publish('shortcutService', new ShortcutService())
+  publish('rootService', new RootService())
+  publish('diagnosticService', new DiagnosticService())
+  publish('interfaceService', new InterfaceService())
+  publish('launchService', new LaunchService())
+  publish('debugService', new DebugService())
+  publish('commandService', new CommandService())
+  publish('agentService', new AgentService())
+  publish('mpeService', new MpeService())
 
   pipelineLanguageServices = [
     new PipelineCodeLensProvider(),
@@ -110,6 +118,7 @@ export async function init(ctx: vscode.ExtensionContext) {
   await services.diagnosticService.init()
   await services.statusBarService.init()
   await services.agentService.init()
+  await services.mpeService.init()
 
   for (const service of pipelineLanguageServices) {
     await service.init()

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -47,7 +47,7 @@ export class MpeService extends BaseService {
     this.defer = interfaceService.onResourceChanged(updateAvailability)
     await updateAvailability()
     this.defer = vscode.workspace.onDidCloseTextDocument(doc => {
-      this.panels.get(doc.uri.toString())?.dispose()
+      this.panels.get(doc.uri.toString())?.close()
     })
   }
 
@@ -129,10 +129,10 @@ class MpePanel implements vscode.Disposable {
     this.disposables.push(
       vscode.workspace.onDidRenameFiles(event => {
         if (event.files.some(file => file.oldUri.toString() === this.document.uri.toString()))
-          this.dispose()
+          this.close()
       }),
       vscode.workspace.onDidDeleteFiles(event => {
-        if (event.files.some(uri => uri.toString() === this.document.uri.toString())) this.dispose()
+        if (event.files.some(uri => uri.toString() === this.document.uri.toString())) this.close()
       })
     )
   }
@@ -341,6 +341,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private flush() {
     const queued = this.queue.splice(0)
     queued.forEach(message => this.send(message))
+  }
+  close() {
+    if (!this.disposed) this.panel.dispose()
   }
   dispose() {
     if (this.disposed) return

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -9,6 +9,7 @@ import { logger } from '../utils/logger'
 import { BaseService } from './context'
 import {
   type MpeProtocolMessage,
+  hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isMpeReadyForRequest,
   mpeProtocol,
@@ -31,6 +32,19 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 function errorCode(error: unknown) {
   if (!error || typeof error !== 'object' || !('code' in error)) return 'save_failed'
   return typeof error.code === 'string' ? error.code : 'save_failed'
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, character => {
+    const entities: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }
+    return entities[character]
+  })
 }
 
 export class MpeService extends BaseService {
@@ -95,7 +109,8 @@ class MpePanel implements vscode.Disposable {
   private ready = false
   private disposed = false
   private queue: MpeProtocolMessage[] = []
-  private pendingSave?: { requestId: string; documentVersion: number }
+  private pendingSave?: { requestId: string; documentVersion: number; force: boolean }
+  private loadedDocumentVersion?: number
   private saveTimeout?: ReturnType<typeof setTimeout>
   private requestCounter = 0
   private readonly disposables: vscode.Disposable[] = []
@@ -147,7 +162,7 @@ class MpePanel implements vscode.Disposable {
       if (parsed.protocol !== 'https:' && !localHttp)
         throw new Error('URL must use HTTPS (HTTP is only allowed for localhost)')
     } catch (error) {
-      this.panel.webview.html = `<p>MPE URL is invalid: ${String(error)}</p>`
+      this.panel.webview.html = `<p>MPE URL is invalid: ${escapeHtml(String(error))}</p>`
       return
     }
     const origin = parsed.origin
@@ -171,7 +186,7 @@ class MpePanel implements vscode.Disposable {
           allowCustomTemplate: true
         },
         ui: { hideHeader: false, hideToolbar: false, hiddenPanels: [] },
-        host: { id: 'mse', name: 'Maa Pipeline Support', repositoryUrl }
+        host: { id: 'mse', name: 'MSE', repositoryUrl }
       }
     }
     this.panel.webview.html = `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{box-sizing:border-box;margin:0;padding:0;width:100%;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style></head><body><iframe id="mpe" src="${frameUrl}" title="MaaPipelineEditor"></iframe><script nonce="${nonce}">
@@ -208,7 +223,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         this.load(message.requestId)
         break
       case 'mpe:saveRequest':
-        this.requestSave(message.requestId)
+        this.requestSave(message)
         break
       case 'mpe:saveData':
         this.applySave(message)
@@ -222,6 +237,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private load(requestId?: string) {
     try {
       const data = parsePipeline(this.document.getText())
+      this.loadedDocumentVersion = this.document.version
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
@@ -240,9 +256,15 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     }
   }
 
-  private requestSave(requestId?: string) {
+  private requestSave(message: MpeProtocolMessage) {
+    const requestId = message.requestId
     if (!requestId || this.pendingSave) return
-    this.pendingSave = { requestId, documentVersion: this.document.version }
+    const payload = asRecord(message.payload)
+    this.pendingSave = {
+      requestId,
+      documentVersion: this.document.version,
+      force: payload?.force === true
+    }
     this.saveTimeout = setTimeout(() => {
       if (this.pendingSave?.requestId !== requestId) return
       this.pendingSave = undefined
@@ -273,10 +295,28 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     this.pendingSave = undefined
     if (this.saveTimeout) clearTimeout(this.saveTimeout)
     try {
-      if (this.document.version !== pending.documentVersion)
-        throw Object.assign(new Error('Source document changed while saving'), {
-          code: 'document_changed'
+      if (
+        !pending.force &&
+        hasDocumentVersionConflict(
+          this.loadedDocumentVersion,
+          pending.documentVersion,
+          this.document.version
+        )
+      ) {
+        this.send({
+          protocol: mpeProtocol,
+          version: mpeProtocolVersion,
+          type: 'mpe:saveResult',
+          requestId: pending.requestId,
+          payload: {
+            success: false,
+            code: 'document_changed',
+            message: 'The host document has changed',
+            canForce: true
+          }
         })
+        return
+      }
       const data = asRecord(asRecord(message.payload)?.data)
       if (!data)
         throw Object.assign(new Error('MPE returned invalid Pipeline data'), {
@@ -295,6 +335,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       )
       if (!(await vscode.workspace.applyEdit(edit)))
         throw new Error('VS Code rejected the document edit')
+      this.loadedDocumentVersion = this.document.version
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from 'node:crypto'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+
+import type { AbsolutePath } from '@nekosu/maa-pipeline-manager'
+
+import { isMaaAssistantArknights } from '../utils/fs'
+import { logger } from '../utils/logger'
+import { BaseService } from './context'
+import {
+  type MpeProtocolMessage,
+  isCompatibleMpeMessage,
+  isMpeReadyForRequest,
+  mpeProtocol,
+  mpeProtocolVersion,
+  normalizeExternalUrl,
+  parsePipeline,
+  updatePipelineText
+} from './mpeProtocol'
+import { interfaceService } from './registry'
+
+const repositoryUrl = 'https://github.com/neko-para/maa-support-extension'
+const defaultUrl = 'https://mpe.codax.site/stable/'
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function errorCode(error: unknown) {
+  if (!error || typeof error !== 'object' || !('code' in error)) return 'save_failed'
+  return typeof error.code === 'string' ? error.code : 'save_failed'
+}
+
+export class MpeService extends BaseService {
+  private readonly panels = new Map<string, MpePanel>()
+
+  async init() {
+    const updateAvailability = () =>
+      vscode.commands.executeCommand(
+        'setContext',
+        'maa.pipelineEditorAvailable',
+        !!vscode.window.activeTextEditor && this.supported(vscode.window.activeTextEditor.document)
+      )
+    this.defer = vscode.window.onDidChangeActiveTextEditor(updateAvailability)
+    this.defer = interfaceService.onResourceChanged(updateAvailability)
+    await updateAvailability()
+    this.defer = vscode.workspace.onDidCloseTextDocument(doc => {
+      this.panels.get(doc.uri.toString())?.dispose()
+    })
+  }
+
+  dispose() {
+    for (const panel of this.panels.values()) panel.panel.dispose()
+    this.panels.clear()
+    super.dispose()
+  }
+
+  async open(uri: vscode.Uri) {
+    const doc = await vscode.workspace.openTextDocument(uri)
+    if (!this.supported(doc)) {
+      vscode.window.showErrorMessage(
+        `Cannot open ${path.basename(uri.fsPath)} in MPE: unsupported Pipeline file`
+      )
+      return false
+    }
+    const key = uri.toString()
+    const existing = this.panels.get(key)
+    if (existing) {
+      existing.panel.reveal()
+      return true
+    }
+    const panel = new MpePanel(doc)
+    this.panels.set(key, panel)
+    panel.onDispose = () => this.panels.delete(key)
+    await panel.start()
+    return true
+  }
+
+  supported(doc: vscode.TextDocument) {
+    if (
+      isMaaAssistantArknights ||
+      doc.uri.scheme !== 'file' ||
+      !/\.(json|jsonc)$/i.test(doc.fileName)
+    )
+      return false
+    const layer = interfaceService.interfaceBundle?.locateLayer(doc.uri.fsPath as AbsolutePath)
+    return !!layer && !layer[2] && !interfaceService.shouldFilter(doc.uri)
+  }
+}
+
+class MpePanel implements vscode.Disposable {
+  readonly panel: vscode.WebviewPanel
+  private ready = false
+  private disposed = false
+  private queue: MpeProtocolMessage[] = []
+  private pendingSave?: { requestId: string; documentVersion: number }
+  private saveTimeout?: ReturnType<typeof setTimeout>
+  private requestCounter = 0
+  private readonly disposables: vscode.Disposable[] = []
+  onDispose = () => {}
+
+  constructor(private readonly document: vscode.TextDocument) {
+    this.panel = vscode.window.createWebviewPanel(
+      'maa.mpe',
+      `MPE: ${path.basename(document.fileName)}`,
+      vscode.ViewColumn.Active,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: []
+      }
+    )
+    this.panel.webview.options = { enableScripts: true, localResourceRoots: [] }
+    this.panel.webview.onDidReceiveMessage(
+      message => this.receive(message),
+      undefined,
+      this.disposables
+    )
+    this.panel.onDidDispose(() => this.dispose(), undefined, this.disposables)
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument(event => {
+        if (event.document.uri.toString() === this.document.uri.toString() && !this.pendingSave) {
+          logger.info(`MPE source document changed: ${path.basename(this.document.fileName)}`)
+        }
+      })
+    )
+    this.disposables.push(
+      vscode.workspace.onDidRenameFiles(event => {
+        if (event.files.some(file => file.oldUri.toString() === this.document.uri.toString()))
+          this.dispose()
+      }),
+      vscode.workspace.onDidDeleteFiles(event => {
+        if (event.files.some(uri => uri.toString() === this.document.uri.toString())) this.dispose()
+      })
+    )
+  }
+
+  async start() {
+    const url = vscode.workspace.getConfiguration('maa').get('pipelineEditorUrl', defaultUrl)
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+      const localHttp =
+        parsed.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)
+      if (parsed.protocol !== 'https:' && !localHttp)
+        throw new Error('URL must use HTTPS (HTTP is only allowed for localhost)')
+    } catch (error) {
+      this.panel.webview.html = `<p>MPE URL is invalid: ${String(error)}</p>`
+      return
+    }
+    const origin = parsed.origin
+    const frameUrl = new URL(parsed)
+    frameUrl.searchParams.set('embed', 'true')
+    frameUrl.searchParams.set('origin', 'vscode-maa')
+    const nonce = randomUUID()
+    const csp = `default-src 'none'; frame-src ${origin}; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';`
+    this.initMessage = {
+      protocol: mpeProtocol,
+      version: mpeProtocolVersion,
+      type: 'mpe:init',
+      requestId: `mse-init-${Date.now()}-${++this.requestCounter}`,
+      payload: {
+        capabilities: {
+          readOnly: false,
+          allowCopy: true,
+          allowUndoRedo: true,
+          allowAutoLayout: true,
+          allowSearch: true,
+          allowCustomTemplate: true
+        },
+        ui: { hideHeader: false, hideToolbar: false, hiddenPanels: [] },
+        host: { id: 'mse', name: 'Maa Pipeline Support', repositoryUrl }
+      }
+    }
+    this.panel.webview.html = `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{box-sizing:border-box;margin:0;padding:0;width:100%;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style></head><body><iframe id="mpe" src="${frameUrl}" title="MaaPipelineEditor"></iframe><script nonce="${nonce}">
+const api=acquireVsCodeApi(), frame=document.getElementById('mpe');
+window.addEventListener('message',e=>{if(e.source===frame.contentWindow&&e.origin==='${origin}'&&e.data?.protocol==='mpe-embed')api.postMessage(e.data);else if(e.source!==frame.contentWindow)frame.contentWindow?.postMessage(e.data,'${origin}')});
+frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
+</script></body></html>`
+  }
+
+  private initMessage?: MpeProtocolMessage
+
+  private receive(value: unknown) {
+    if (asRecord(value)?.builtin === 'mpe-host-ready') {
+      this.ready = false
+      this.pendingSave = undefined
+      if (this.saveTimeout) clearTimeout(this.saveTimeout)
+      if (this.initMessage) this.panel.webview.postMessage(this.initMessage)
+      return
+    }
+    if (!isCompatibleMpeMessage(value)) return
+    const message = value
+    switch (message.type) {
+      case 'mpe:ready':
+        if (
+          !this.initMessage?.requestId ||
+          !isMpeReadyForRequest(message, this.initMessage.requestId)
+        )
+          return
+        this.ready = true
+        this.flush()
+        this.load(`mse-load-${Date.now()}-${++this.requestCounter}`)
+        break
+      case 'mpe:reloadRequest':
+        this.load(message.requestId)
+        break
+      case 'mpe:saveRequest':
+        this.requestSave(message.requestId)
+        break
+      case 'mpe:saveData':
+        this.applySave(message)
+        break
+      case 'mpe:openExternalRequest':
+        void this.openExternal(asRecord(message.payload)?.url)
+        break
+    }
+  }
+
+  private load(requestId?: string) {
+    try {
+      const data = parsePipeline(this.document.getText())
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:loadPipeline',
+        requestId,
+        payload: { fileName: path.basename(this.document.fileName), data }
+      })
+    } catch (error) {
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:error',
+        requestId,
+        payload: { code: 'invalid_pipeline', message: String(error) }
+      })
+    }
+  }
+
+  private requestSave(requestId?: string) {
+    if (!requestId || this.pendingSave) return
+    this.pendingSave = { requestId, documentVersion: this.document.version }
+    this.saveTimeout = setTimeout(() => {
+      if (this.pendingSave?.requestId !== requestId) return
+      this.pendingSave = undefined
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:saveResult',
+        requestId,
+        payload: {
+          success: false,
+          code: 'save_timeout',
+          message: 'Timed out waiting for MPE save data'
+        }
+      })
+    }, 10_000)
+    this.send({
+      protocol: mpeProtocol,
+      version: mpeProtocolVersion,
+      type: 'mpe:save',
+      requestId,
+      payload: {}
+    })
+  }
+
+  private async applySave(message: MpeProtocolMessage) {
+    const pending = this.pendingSave
+    if (!pending || message.requestId !== pending.requestId) return
+    this.pendingSave = undefined
+    if (this.saveTimeout) clearTimeout(this.saveTimeout)
+    try {
+      if (this.document.version !== pending.documentVersion)
+        throw Object.assign(new Error('Source document changed while saving'), {
+          code: 'document_changed'
+        })
+      const data = asRecord(asRecord(message.payload)?.data)
+      if (!data)
+        throw Object.assign(new Error('MPE returned invalid Pipeline data'), {
+          code: 'invalid_pipeline'
+        })
+      const original = this.document.getText()
+      const edits = updatePipelineText(original, parsePipeline(original), data)
+      const edit = new vscode.WorkspaceEdit()
+      edit.replace(
+        this.document.uri,
+        new vscode.Range(
+          this.document.positionAt(0),
+          this.document.positionAt(this.document.getText().length)
+        ),
+        edits
+      )
+      if (!(await vscode.workspace.applyEdit(edit)))
+        throw new Error('VS Code rejected the document edit')
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:saveResult',
+        requestId: pending.requestId,
+        payload: { success: true, documentVersion: this.document.version }
+      })
+    } catch (error) {
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:saveResult',
+        requestId: pending.requestId,
+        payload: {
+          success: false,
+          code: errorCode(error),
+          message: String(error)
+        }
+      })
+    }
+  }
+
+  private async openExternal(value: unknown) {
+    const url = normalizeExternalUrl(value)
+    if (!url) {
+      logger.warn('MPE rejected an invalid external URL request')
+      return
+    }
+
+    try {
+      if (!(await vscode.env.openExternal(vscode.Uri.parse(url)))) {
+        logger.warn('VS Code did not open the external URL requested by MPE')
+      }
+    } catch (error) {
+      logger.error(`Failed to open an external URL requested by MPE: ${String(error)}`)
+    }
+  }
+
+  private send(message: MpeProtocolMessage) {
+    if (this.disposed) return
+    if (!this.ready && message.type !== 'mpe:init') this.queue.push(message)
+    else this.panel.webview.postMessage(message)
+  }
+  private flush() {
+    const queued = this.queue.splice(0)
+    queued.forEach(message => this.send(message))
+  }
+  dispose() {
+    if (this.disposed) return
+    this.disposed = true
+    this.pendingSave = undefined
+    if (this.saveTimeout) clearTimeout(this.saveTimeout)
+    this.disposables.splice(0).forEach(disposable => disposable.dispose())
+    this.onDispose()
+  }
+}

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -10,7 +10,7 @@ import {
 const formatting: FormattingOptions = { tabSize: 2, insertSpaces: true, eol: '\n' }
 
 export const mpeProtocol = 'mpe-embed'
-export const mpeProtocolVersion = '1.2.0'
+export const mpeProtocolVersion = '1.3.0'
 
 export type MpeProtocolMessage = {
   protocol: typeof mpeProtocol
@@ -55,12 +55,24 @@ export function updatePipelineText(
   previous: Record<string, unknown>,
   next: Record<string, unknown>
 ) {
+  // `next` is the complete Pipeline snapshot returned by MPE, not a partial patch.
   let result = text
   for (const key of new Set([...Object.keys(previous), ...Object.keys(next)])) {
     if (JSON.stringify(previous[key]) === JSON.stringify(next[key])) continue
     result = applyEdits(result, modify(result, [key], next[key], { formattingOptions: formatting }))
   }
   return result
+}
+
+export function hasDocumentVersionConflict(
+  loadedVersion: number | undefined,
+  requestedVersion: number,
+  currentVersion: number
+) {
+  return (
+    currentVersion !== requestedVersion ||
+    (loadedVersion !== undefined && currentVersion !== loadedVersion)
+  )
 }
 
 export function normalizeExternalUrl(value: unknown): string | null {

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -1,0 +1,75 @@
+import {
+  type FormattingOptions,
+  type ParseError,
+  applyEdits,
+  modify,
+  parse,
+  printParseErrorCode
+} from 'jsonc-parser'
+
+const formatting: FormattingOptions = { tabSize: 2, insertSpaces: true, eol: '\n' }
+
+export const mpeProtocol = 'mpe-embed'
+export const mpeProtocolVersion = '1.2.0'
+
+export type MpeProtocolMessage = {
+  protocol: typeof mpeProtocol
+  version: string
+  type: string
+  requestId?: string
+  payload?: unknown
+}
+
+export function isCompatibleMpeMessage(value: unknown): value is MpeProtocolMessage {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const message = value as Record<string, unknown>
+  return (
+    message.protocol === mpeProtocol &&
+    typeof message.version === 'string' &&
+    message.version.split('.')[0] === mpeProtocolVersion.split('.')[0] &&
+    typeof message.type === 'string' &&
+    (message.requestId === undefined || typeof message.requestId === 'string')
+  )
+}
+
+export function isMpeReadyForRequest(value: unknown, requestId: string) {
+  return (
+    isCompatibleMpeMessage(value) && value.type === 'mpe:ready' && value.requestId === requestId
+  )
+}
+
+export function parsePipeline(text: string) {
+  const errors: ParseError[] = []
+  const data = parse(text, errors, { allowTrailingComma: true, disallowComments: false })
+  if (errors.length || !data || typeof data !== 'object' || Array.isArray(data)) {
+    const detail = errors[0]
+      ? printParseErrorCode(errors[0].error)
+      : 'Pipeline must be a JSON object'
+    throw new Error(`Pipeline JSONC parse failed: ${detail}`)
+  }
+  return data as Record<string, unknown>
+}
+
+export function updatePipelineText(
+  text: string,
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>
+) {
+  let result = text
+  for (const key of new Set([...Object.keys(previous), ...Object.keys(next)])) {
+    if (JSON.stringify(previous[key]) === JSON.stringify(next[key])) continue
+    result = applyEdits(result, modify(result, [key], next[key], { formattingOptions: formatting }))
+  }
+  return result
+}
+
+export function normalizeExternalUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  } catch {
+    return null
+  }
+}

--- a/pkgs/extension/src/service/registry.ts
+++ b/pkgs/extension/src/service/registry.ts
@@ -4,6 +4,7 @@ import type { DebugService } from './debug'
 import type { DiagnosticService } from './diagnostic'
 import type { InterfaceService } from './interface'
 import type { LaunchService } from './launch'
+import type { MpeService } from './mpe'
 import type { NativeService } from './native'
 import type { RootService } from './root'
 import type { ServerService } from './server'
@@ -24,6 +25,7 @@ export type ServiceRegistry = {
   diagnosticService: DiagnosticService
   statusBarService: StatusBarService
   agentService: AgentService
+  mpeService: MpeService
 }
 
 export let stateService: StateService
@@ -38,18 +40,20 @@ export let commandService: CommandService
 export let diagnosticService: DiagnosticService
 export let statusBarService: StatusBarService
 export let agentService: AgentService
+export let mpeService: MpeService
 
-export function registerServices(services: ServiceRegistry) {
-  stateService = services.stateService
-  nativeService = services.nativeService
-  serverService = services.serverService
-  shortcutService = services.shortcutService
-  rootService = services.rootService
-  interfaceService = services.interfaceService
-  launchService = services.launchService
-  debugService = services.debugService
-  commandService = services.commandService
-  diagnosticService = services.diagnosticService
-  statusBarService = services.statusBarService
-  agentService = services.agentService
+export function registerServices(services: Partial<ServiceRegistry>) {
+  if (services.stateService) stateService = services.stateService
+  if (services.nativeService) nativeService = services.nativeService
+  if (services.serverService) serverService = services.serverService
+  if (services.shortcutService) shortcutService = services.shortcutService
+  if (services.rootService) rootService = services.rootService
+  if (services.interfaceService) interfaceService = services.interfaceService
+  if (services.launchService) launchService = services.launchService
+  if (services.debugService) debugService = services.debugService
+  if (services.commandService) commandService = services.commandService
+  if (services.diagnosticService) diagnosticService = services.diagnosticService
+  if (services.statusBarService) statusBarService = services.statusBarService
+  if (services.agentService) agentService = services.agentService
+  if (services.mpeService) mpeService = services.mpeService
 }

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -75,3 +75,10 @@ test('MPE host uses a nonce for its inline bridge script', () => {
   assert.match(source, /<script nonce="\$\{nonce\}">/)
   assert.doesNotMatch(source, /script-src 'unsafe-inline'/)
 })
+
+test('MPE document lifecycle closes the underlying webview panel', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /onDidCloseTextDocument\(doc => \{[\s\S]*?\.close\(\)\n    \}\)/)
+  assert.match(source, /close\(\) \{\n    if \(!this\.disposed\) this\.panel\.dispose\(\)\n  \}/)
+})

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
+  hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isMpeReadyForRequest,
   mpeProtocol,
@@ -26,6 +27,35 @@ test('updates pipeline keys while preserving unrelated comments', () => {
 
   assert.match(result, /keep this comment/)
   assert.deepEqual(parsePipeline(result), next)
+})
+
+test('updates pipeline keys with complete snapshot deletion semantics', () => {
+  const original = '{\n  "A": {},\n  "B": {}\n}\n'
+  const result = updatePipelineText(original, parsePipeline(original), { A: { next: ['C'] } })
+
+  assert.deepEqual(parsePipeline(result), { A: { next: ['C'] } })
+})
+
+test('detects document changes before and during an MPE save', () => {
+  assert.equal(hasDocumentVersionConflict(3, 3, 3), false)
+  assert.equal(hasDocumentVersionConflict(3, 4, 4), true)
+  assert.equal(hasDocumentVersionConflict(3, 3, 4), true)
+  assert.equal(hasDocumentVersionConflict(undefined, 3, 3), false)
+})
+
+test('delegates document conflict choices to the MPE protocol', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /!pending\.force/)
+  assert.match(source, /code: 'document_changed'/)
+  assert.match(source, /canForce: true/)
+  assert.doesNotMatch(source, /showWarningMessage\(/)
+})
+
+test('MPE host identifies itself with the MSE product name', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /host: \{ id: 'mse', name: 'MSE', repositoryUrl \}/)
 })
 
 test('rejects malformed and non-object pipeline content', () => {

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -109,6 +109,9 @@ test('MPE host uses a nonce for its inline bridge script', () => {
 test('MPE document lifecycle closes the underlying webview panel', () => {
   const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
 
-  assert.match(source, /onDidCloseTextDocument\(doc => \{[\s\S]*?\.close\(\)\n    \}\)/)
-  assert.match(source, /close\(\) \{\n    if \(!this\.disposed\) this\.panel\.dispose\(\)\n  \}/)
+  assert.match(source, /onDidCloseTextDocument\(doc => \{[\s\S]*?\.close\(\)\r?\n[ \t]{4}\}\)/)
+  assert.match(
+    source,
+    /close\(\) \{\r?\n[ \t]{4}if \(!this\.disposed\) this\.panel\.dispose\(\)\r?\n[ \t]{2}\}/
+  )
 })

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  isCompatibleMpeMessage,
+  isMpeReadyForRequest,
+  mpeProtocol,
+  mpeProtocolVersion,
+  normalizeExternalUrl,
+  parsePipeline,
+  updatePipelineText
+} from '../src/service/mpeProtocol.ts'
+
+test('parses JSONC pipeline content', () => {
+  assert.deepEqual(parsePipeline('{ // task\n "A": { "next": ["B",], },\n}'), {
+    A: { next: ['B'] }
+  })
+})
+
+test('updates pipeline keys while preserving unrelated comments', () => {
+  const original = '{\n  // keep this comment\n  "A": { "next": ["B"] },\n  "B": {}\n}\n'
+  const previous = parsePipeline(original)
+  const next = { A: { next: ['C'] }, C: {} }
+  const result = updatePipelineText(original, previous, next)
+
+  assert.match(result, /keep this comment/)
+  assert.deepEqual(parsePipeline(result), next)
+})
+
+test('rejects malformed and non-object pipeline content', () => {
+  assert.throws(() => parsePipeline('{ invalid }'), /parse failed/)
+  assert.throws(() => parsePipeline('[]'), /JSON object/)
+})
+
+test('MPE host resets VS Code webview body spacing', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /html,body\{[^}]*margin:0;[^}]*padding:0;/)
+  assert.match(source, /iframe\{display:block;width:100%;height:100%;border:0\}/)
+})
+
+test('MPE host only accepts HTTP(S) external URLs', () => {
+  assert.equal(normalizeExternalUrl('https://example.com/docs'), 'https://example.com/docs')
+  assert.equal(
+    normalizeExternalUrl('http://localhost:5173/help?q=1'),
+    'http://localhost:5173/help?q=1'
+  )
+  assert.equal(normalizeExternalUrl('javascript:alert(1)'), null)
+  assert.equal(normalizeExternalUrl('file:///C:/secret.txt'), null)
+  assert.equal(normalizeExternalUrl('not a url'), null)
+  assert.equal(normalizeExternalUrl(undefined), null)
+})
+
+test('validates MPE protocol versions and init request correlation', () => {
+  const ready = {
+    protocol: mpeProtocol,
+    version: mpeProtocolVersion,
+    type: 'mpe:ready',
+    requestId: 'init-1'
+  }
+
+  assert.equal(isCompatibleMpeMessage(ready), true)
+  assert.equal(isCompatibleMpeMessage({ ...ready, version: '2.0.0' }), false)
+  assert.equal(isCompatibleMpeMessage({ ...ready, protocol: 'other' }), false)
+  assert.equal(isMpeReadyForRequest(ready, 'init-1'), true)
+  assert.equal(isMpeReadyForRequest(ready, 'init-2'), false)
+  assert.equal(isMpeReadyForRequest({ ...ready, type: 'mpe:loadResult' }, 'init-1'), false)
+})
+
+test('MPE host uses a nonce for its inline bridge script', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /script-src 'nonce-\$\{nonce\}'/)
+  assert.match(source, /<script nonce="\$\{nonce\}">/)
+  assert.doesNotMatch(source, /script-src 'unsafe-inline'/)
+})

--- a/pkgs/extension/test/serviceArchitecture.test.ts
+++ b/pkgs/extension/test/serviceArchitecture.test.ts
@@ -62,6 +62,16 @@ test('registry publishes the composed service instances', () => {
   assert.equal(agentService, services.agentService)
 })
 
+test('incremental registration preserves services published earlier', () => {
+  const state = { name: 'state' }
+  const native = { name: 'native' }
+
+  registerServices({ stateService: state } as unknown as Partial<ServiceRegistry>)
+  registerServices({ nativeService: native } as unknown as Partial<ServiceRegistry>)
+
+  assert.equal(stateService, state)
+})
+
 test('service implementations do not import the composition root', async () => {
   const violations: string[] = []
 

--- a/pkgs/extension/test/serviceArchitecture.test.ts
+++ b/pkgs/extension/test/serviceArchitecture.test.ts
@@ -7,6 +7,7 @@ import ts from 'typescript'
 import {
   type ServiceRegistry,
   agentService,
+  mpeService,
   registerServices,
   stateService
 } from '../src/service/registry.ts'
@@ -52,7 +53,8 @@ test('registry publishes the composed service instances', () => {
       'commandService',
       'diagnosticService',
       'statusBarService',
-      'agentService'
+      'agentService',
+      'mpeService'
     ].map(name => [name, { name }])
   ) as unknown as ServiceRegistry
 
@@ -60,6 +62,7 @@ test('registry publishes the composed service instances', () => {
 
   assert.equal(stateService, services.stateService)
   assert.equal(agentService, services.agentService)
+  assert.equal(mpeService, services.mpeService)
 })
 
 test('incremental registration preserves services published earlier', () => {
@@ -70,6 +73,40 @@ test('incremental registration preserves services published earlier', () => {
   registerServices({ nativeService: native } as unknown as Partial<ServiceRegistry>)
 
   assert.equal(stateService, state)
+})
+
+test('composition root publishes every registered service', async () => {
+  const source = await parse(compositionRoot)
+  const published = new Set<string>()
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'publish' &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      published.add(node.arguments[0].text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+
+  assert.deepEqual([...published].sort(), [
+    'agentService',
+    'commandService',
+    'debugService',
+    'diagnosticService',
+    'interfaceService',
+    'launchService',
+    'mpeService',
+    'nativeService',
+    'rootService',
+    'serverService',
+    'shortcutService',
+    'stateService',
+    'statusBarService'
+  ])
 })
 
 test('service implementations do not import the composition root', async () => {

--- a/release/README.md
+++ b/release/README.md
@@ -23,6 +23,10 @@
   - 执行任务
 - 截取图片 (依赖控制器提供截图能力)
 - 裁剪图片
+- MaaPipelineEditor 图形化编辑 (仅 MaaFramework Pipeline)
+  - 从文件树、编辑器正文或标题栏打开 JSON/JSONC Pipeline
+  - 保存时写回 VS Code 文档并保留撤销和未保存状态
+  - 使用“从 MSE 同步”重新载入当前文档内容
 
 ## For MaaFramework/MaaAssistantArknights project, providing following features:
 
@@ -47,6 +51,10 @@
   - Run tasks
 - Take screenshots (Relying on controllers for screenshot ability)
 - Crop images
+- MaaPipelineEditor graphical editing (MaaFramework Pipeline only)
+  - Open JSON/JSONC Pipeline files from Explorer, the editor context menu, or the editor title bar
+  - Write changes back to the VS Code document while preserving undo and dirty state
+  - Reload the current document with "Sync from MSE"
 
 ## 提供的vscode命令
 
@@ -78,6 +86,8 @@
   - 下载并切换插件自身使用的 MaaFramework.
 - Maa: 选择下载源
   - 选择下载插件自身使用的 MaaFramework 的镜像源.
+- 在 MPE 中打开
+  - 使用 MaaPipelineEditor 编辑当前受支持的 MaaFramework Pipeline 文件.
 
 先在 Maa 控制面板点击“激活全局快捷键”，将当前窗口设为唯一执行目标。VS Code 1.128 及以上可在用户 `keybindings.json` 中将上述任一命令配置为系统级快捷键，例如：
 
@@ -120,6 +130,8 @@ Use Ctrl Shift P (Command Shift P for MacOS) to open command panel and search
   - Download and change the version of MaaFramework used by extension.
 - Maa: select fetch registry
   - Select the mirrors to download MaaFramework used by extension.
+- Maa: open in MaaPipelineEditor
+  - Edit the current supported MaaFramework Pipeline file with MaaPipelineEditor.
 
 First click **Activate Global Shortcuts** in the Maa control panel to make that window the sole command target. With VS Code 1.128 or later, any command above can be configured as an OS-level shortcut in your user `keybindings.json`, for example:
 

--- a/release/package.json
+++ b/release/package.json
@@ -75,6 +75,10 @@
       {
         "title": "Maa(debug): query location",
         "command": "maa.debug.query-location"
+      },
+      {
+        "title": "%maa.command.open-mpe%",
+        "command": "maa.open-mpe"
       }
     ],
     "viewsContainers": {
@@ -139,6 +143,11 @@
           "type": "boolean",
           "description": "Use refactored pipeline completion provider. Set to false to fall back to legacy completion",
           "default": true
+        },
+        "maa.pipelineEditorUrl": {
+          "type": "string",
+          "description": "%maa.setting.pipeline-editor-url%",
+          "default": "https://mpe.codax.site/stable/"
         }
       }
     },
@@ -148,6 +157,25 @@
           "command": "maa.open-crop",
           "when": "resourceExtname == .png",
           "group": "navigation@100"
+        },
+        {
+          "command": "maa.open-mpe",
+          "when": "resourceExtname =~ /\\.(json|jsonc)$/",
+          "group": "navigation@110"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "maa.open-mpe",
+          "when": "maa.pipelineEditorAvailable",
+          "group": "navigation@110"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "maa.open-mpe",
+          "when": "maa.pipelineEditorAvailable",
+          "group": "navigation@110"
         }
       ]
     },

--- a/release/package.nls.json
+++ b/release/package.nls.json
@@ -11,9 +11,11 @@
   "maa.command.reveal-control-panel": "Maa: reveal control panel",
   "maa.command.native.select-maa": "Maa: select MaaFramework version",
   "maa.command.native.select-registry": "Maa: select fetch registry",
+  "maa.command.open-mpe": "Maa: open in MaaPipelineEditor",
   "maa.view.control-panel.title": "Maa Control Panel",
   "maa.setting.output-level": "Maa Output Channel Logging Level (Restart to apply)",
   "maa.setting.agent-timeout": "Maa Agent Launch Timeout (ms), set -1 to disable.",
   "maa.setting.launch-analyzer-url": "Analyzer iframe URL for Maa Launch panel.",
-  "maa.setting.webview-tooltip": "Disable hover tooltips in webview panels."
+  "maa.setting.webview-tooltip": "Disable hover tooltips in webview panels.",
+  "maa.setting.pipeline-editor-url": "MaaPipelineEditor iframe URL (HTTPS required; HTTP is allowed for localhost development)."
 }

--- a/release/package.nls.zh-cn.json
+++ b/release/package.nls.zh-cn.json
@@ -11,9 +11,11 @@
   "maa.command.reveal-control-panel": "Maa: 展示控制面板",
   "maa.command.native.select-maa": "Maa: 选择 MaaFramework 版本",
   "maa.command.native.select-registry": "Maa: 选择下载源",
+  "maa.command.open-mpe": "在 MPE 中打开",
   "maa.view.control-panel.title": "Maa 控制面板",
   "maa.setting.output-level": "Maa 输出面板日志等级 (重启生效)",
   "maa.setting.agent-timeout": "Maa Agent启动超时时间 (ms), 使用 -1 来禁用.",
   "maa.setting.launch-analyzer-url": "Maa Launch 面板中 Analyzer iframe 的地址。",
-  "maa.setting.webview-tooltip": "关闭 webview 面板中的悬停工具提示。"
+  "maa.setting.webview-tooltip": "关闭 webview 面板中的悬停工具提示。",
+  "maa.setting.pipeline-editor-url": "MaaPipelineEditor iframe 地址（必须使用 HTTPS；本机开发可使用 localhost HTTP）。"
 }


### PR DESCRIPTION
## Summary

为 Maa Support Extension 接入 MaaPipelineEditor（MPE）iframe 编辑能力，使 MaaFramework Pipeline 文件可以直接在 VS Code 中使用完整、可编辑的 MPE 进行图形化编辑。

## User Experience

支持从以下入口打开当前 Pipeline 文件：

- VS Code 文件资源管理器右键菜单
- JSON/JSONC 编辑器正文右键菜单
- 编辑器标题栏
- 命令面板：`Maa: open in MaaPipelineEditor`

行为说明：

- 仅对受支持的 MaaFramework Pipeline JSON/JSONC 文件启用。
- 同一文件重复打开时复用已有 MPE 标签页。
- 不同文件使用独立的面板和保存状态。
- 初次打开和“从 MSE 同步”读取当前 `TextDocument` 内容，包括尚未落盘的修改。
- MPE 保留 Header、工具栏、画布和其他功能模块。
- MPE 保存内容写回 VS Code `TextDocument`，保留 dirty、undo/redo 和正常保存语义。
- 不会绕过 VS Code 直接覆盖磁盘。
- MPE 内的外部链接由 MSE 通过 `vscode.env.openExternal` 打开。

## Implementation

### MPE Host

新增 `MpeService` 和 MPE 面板管理逻辑：

- 按文档 URI 管理面板实例。
- 支持面板复用和多文件隔离。
- 监听 TextDocument 关闭、重命名、删除和变更。
- Webview/iframe 未 ready 前缓存消息。
- iframe 刷新后重新握手并加载文档。
- 面板销毁时释放 listener、计时器和待处理状态。

### Protocol

使用 MPE iframe v1.2.0 协议：

```text
MSE -> MPE: mpe:init
MPE -> MSE: mpe:ready
MSE -> MPE: mpe:loadPipeline
MPE -> MSE: mpe:loadResult

MPE -> MSE: mpe:saveRequest
MSE -> MPE: mpe:save
MPE -> MSE: mpe:saveData
MSE -> MPE: mpe:saveResult

MPE -> MSE: mpe:reloadRequest
MSE -> MPE: mpe:loadPipeline / mpe:error

MPE -> MSE: mpe:openExternalRequest
```

宿主侧会：

- 校验协议标识和协议主版本。
- 严格关联 `mpe:init` / `mpe:ready` 的 requestId。
- 严格关联保存、同步和错误响应的 requestId。
- 只允许 HTTP(S) 外链。
- 拒绝 `javascript:`、`file:` 等危险协议。
- 使用精确 iframe origin 和 CSP nonce。

### Save Pipeline

保存流程使用 `jsonc-parser` 生成结构化文本编辑，并通过 `WorkspaceEdit` 写回原始文档：

- 保留 JSONC 注释和无关文本。
- 保留 VS Code dirty 状态。
- 保留 undo/redo 行为。
- 保存过程中检测 TextDocument 版本变化。
- 保存失败、文档冲突和超时会返回明确错误。

## Configuration

新增配置：

```json
{
  "maa.pipelineEditorUrl": "https://mpe.codax.site/stable/"
}
```

生产地址要求使用 HTTPS；本机开发时允许 localhost HTTP。

## Documentation

同步更新：

- `release/README.md`
- `release/package.json`
- `release/package.nls.json`
- `release/package.nls.zh-cn.json`
- `docs/extension/tech/README.md`

## Tests

已通过：

- `pnpm lint`
- `pnpm test`
- `pnpm --filter @mse/extension test`
- `pnpm build`
- 本次修改文件的 Prettier check
- 主要功能的本地 release 与手动验证

扩展测试覆盖：

- JSONC Pipeline 解析
- JSONC 文本更新和注释保留
- 非法 Pipeline 拒绝
- HTTP(S) 外链校验
- 危险协议拒绝
- 协议主版本校验
- init requestId 关联
- CSP nonce
- 服务注册架构回归