### PR TITLE
fix(mpe): allow clipboard and load .mpe.json sidecar

### DIFF
--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -131,6 +131,7 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
 - 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与 sidecar 放进同一次 `WorkspaceEdit` 拆回，避免把 `$__mpe_*` 写进 Pipeline
 - sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
+- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开或 JSON 损坏时拒绝加载并报错；若仍保存则保持分离写回，不把 `$__mpe_*` 写进 Pipeline
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
 - MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -131,8 +131,8 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
 - 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与 sidecar 放进同一次 `WorkspaceEdit` 拆回，避免把 `$__mpe_*` 写进 Pipeline
 - sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
-- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错；加载失败后禁止保存，避免空画布覆盖 Pipeline
-- 若仍保存则保持分离写回，不把 `$__mpe_*` 写进 Pipeline
+- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错
+- 未成功加载完成前禁止保存（含加载进行中和加载失败），避免空画布覆盖 Pipeline；加载成功后恢复保存
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
 - MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -129,9 +129,11 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 可从文件树、编辑器正文、编辑器标题栏或命令面板打开
 - 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
+- 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与配置重新拆回原文件和该 sidecar，避免把 `$__mpe_*` 写进 Pipeline
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
 - MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择
+- 嵌入 iframe 会向 MPE 下放剪贴板读写权限，使复制/粘贴走浏览器 Clipboard API 而不是被 Webview Permissions-Policy 拦截
 - MPE 地址可通过 `maa.pipelineEditorUrl` 配置，生产地址要求 HTTPS，本机 localhost 开发地址允许 HTTP
 
 该面板是外部编辑器集成，不改变普通 Pipeline 编辑器、命令和菜单的既有行为。

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -131,7 +131,8 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
 - 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与 sidecar 放进同一次 `WorkspaceEdit` 拆回，避免把 `$__mpe_*` 写进 Pipeline
 - sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
-- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开或 JSON 损坏时拒绝加载并报错；若仍保存则保持分离写回，不把 `$__mpe_*` 写进 Pipeline
+- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错；加载失败后禁止保存，避免空画布覆盖 Pipeline
+- 若仍保存则保持分离写回，不把 `$__mpe_*` 写进 Pipeline
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
 - MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -129,9 +129,10 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 可从文件树、编辑器正文、编辑器标题栏或命令面板打开
 - 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
-- 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与配置重新拆回原文件和该 sidecar，避免把 `$__mpe_*` 写进 Pipeline
+- 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与 sidecar 放进同一次 `WorkspaceEdit` 拆回，避免把 `$__mpe_*` 写进 Pipeline
+- sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
-- MPE 加载后若源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
+- MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
 - MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择
 - 嵌入 iframe 会向 MPE 下放剪贴板读写权限，使复制/粘贴走浏览器 Clipboard API 而不是被 Webview Permissions-Policy 拦截
 - MPE 地址可通过 `maa.pipelineEditorUrl` 配置，生产地址要求 HTTPS，本机 localhost 开发地址允许 HTTP

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,7 +29,7 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、同步、sidecar 配置与保存桥接
+    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、sidecar 与 Pipeline 同一次保存
     ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,8 +29,8 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载、sidecar 与 Pipeline 同一次保存
-    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏判定
+    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载并禁止保存、sidecar 与 Pipeline 同一次保存
+    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏/字段类型判定
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,8 +29,8 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、sidecar 与 Pipeline 同一次保存
-    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分
+    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载、sidecar 与 Pipeline 同一次保存
+    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏判定
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,7 +29,8 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、同步与保存桥接
+    ├── mpe.ts                # MPE iframe 面板、握手、同步、sidecar 配置与保存桥接
+    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,8 +29,8 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载并禁止保存、sidecar 与 Pipeline 同一次保存
-    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏/字段类型判定
+    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载、未成功加载禁止保存、sidecar 与 Pipeline 同一次保存
+    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏/字段类型判定、加载授权
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -9,11 +9,15 @@ import { logger } from '../utils/logger'
 import { BaseService } from './context'
 import {
   type MpeConfig,
+  type MpeLoadAuth,
   type MpeProtocolMessage,
+  beginMpeLoad,
+  finishMpeLoad,
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
+  isMpeSaveAllowed,
   isSeparatedMpeSidecar,
   isSidecarNotFound,
   mergePipelineAndConfig,
@@ -121,7 +125,7 @@ export class MpeService extends BaseService {
 class MpePanel implements vscode.Disposable {
   readonly panel: vscode.WebviewPanel
   private ready = false
-  private loadFailed = false
+  private loadAuth: MpeLoadAuth = 'idle'
   private disposed = false
   private queue: MpeProtocolMessage[] = []
   private pendingSave?: { requestId: string; documentVersion: number; force: boolean }
@@ -218,7 +222,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private receive(value: unknown) {
     if (asRecord(value)?.builtin === 'mpe-host-ready') {
       this.ready = false
-      this.loadFailed = false
+      this.loadAuth = beginMpeLoad()
       this.pendingSave = undefined
       this.loadSeq += 1
       if (this.saveTimeout) clearTimeout(this.saveTimeout)
@@ -255,12 +259,14 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
 
   private async load(requestId?: string) {
     const seq = ++this.loadSeq
+    this.loadAuth = beginMpeLoad()
     try {
       const snapshot = await this.pipelineSnapshot()
       if (this.disposed || seq !== this.loadSeq) {
         return
       }
       this.loadedDocumentVersion = snapshot.version
+      this.loadAuth = finishMpeLoad(true)
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
@@ -272,7 +278,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       if (this.disposed || seq !== this.loadSeq) {
         return
       }
-      this.loadFailed = true
+      this.loadAuth = finishMpeLoad(false)
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
@@ -408,7 +414,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       return true
     }
     try {
-      if (this.loadFailed) {
+      if (!isMpeSaveAllowed(this.loadAuth)) {
         this.send({
           protocol: mpeProtocol,
           version: mpeProtocolVersion,

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -12,6 +12,7 @@ import {
   type MpeProtocolMessage,
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
+  isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
   mergePipelineAndConfig,
   mpeProtocol,
@@ -28,6 +29,7 @@ import { interfaceService } from './registry'
 
 const repositoryUrl = 'https://github.com/neko-para/maa-support-extension'
 const defaultUrl = 'https://mpe.codax.site/stable/'
+const snapshotRetries = 3
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -38,6 +40,10 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 function errorCode(error: unknown) {
   if (!error || typeof error !== 'object' || !('code' in error)) return 'save_failed'
   return typeof error.code === 'string' ? error.code : 'save_failed'
+}
+
+function documentRange(document: vscode.TextDocument) {
+  return new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
 }
 
 function escapeHtml(value: string) {
@@ -120,6 +126,7 @@ class MpePanel implements vscode.Disposable {
   private separatedConfigUri?: vscode.Uri
   private saveTimeout?: ReturnType<typeof setTimeout>
   private requestCounter = 0
+  private loadSeq = 0
   private readonly disposables: vscode.Disposable[] = []
   onDispose = () => {}
 
@@ -209,6 +216,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     if (asRecord(value)?.builtin === 'mpe-host-ready') {
       this.ready = false
       this.pendingSave = undefined
+      this.loadSeq += 1
       if (this.saveTimeout) clearTimeout(this.saveTimeout)
       if (this.initMessage) this.panel.webview.postMessage(this.initMessage)
       return
@@ -242,17 +250,24 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   }
 
   private async load(requestId?: string) {
+    const seq = ++this.loadSeq
     try {
-      const data = await this.pipelineSnapshot()
-      this.loadedDocumentVersion = this.document.version
+      const snapshot = await this.pipelineSnapshot()
+      if (this.disposed || seq !== this.loadSeq) {
+        return
+      }
+      this.loadedDocumentVersion = snapshot.version
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
         type: 'mpe:loadPipeline',
         requestId,
-        payload: { fileName: path.basename(this.document.fileName), data }
+        payload: { fileName: path.basename(this.document.fileName), data: snapshot.data }
       })
     } catch (error) {
+      if (this.disposed || seq !== this.loadSeq) {
+        return
+      }
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
@@ -282,21 +297,31 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   }
 
   private async pipelineSnapshot() {
-    const pipeline = parsePipeline(this.document.getText())
     const sidecarUri = this.sidecarUri()
-    const sidecar = await this.readSidecar(sidecarUri)
-    if (!sidecar) {
-      this.separatedConfigUri = undefined
-      return pipeline
+    for (let attempt = 0; attempt < snapshotRetries; attempt++) {
+      const version = this.document.version
+      const pipeline = parsePipeline(this.document.getText())
+      const sidecar = await this.readSidecar(sidecarUri)
+      if (!isCurrentDocumentSnapshot(version, this.document.version)) {
+        continue
+      }
+      if (!sidecar) {
+        this.separatedConfigUri = undefined
+        return { data: pipeline, version }
+      }
+      this.separatedConfigUri = sidecarUri
+      // mpe:loadPipeline only accepts a combined pipeline object, so merge the sidecar here.
+      return {
+        data: mergePipelineAndConfig(
+          pipeline,
+          sidecar,
+          path.basename(this.document.fileName).replace(/\.(json|jsonc)$/i, ''),
+          Object.keys(pipeline)
+        ),
+        version
+      }
     }
-    this.separatedConfigUri = sidecarUri
-    // mpe:loadPipeline only accepts a combined pipeline object, so merge the sidecar here.
-    return mergePipelineAndConfig(
-      pipeline,
-      sidecar,
-      path.basename(this.document.fileName).replace(/\.(json|jsonc)$/i, ''),
-      Object.keys(pipeline)
-    )
+    throw new Error('Pipeline changed while loading MPE snapshot')
   }
 
   private requestSave(message: MpeProtocolMessage) {
@@ -337,27 +362,33 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     if (!pending || message.requestId !== pending.requestId) return
     this.pendingSave = undefined
     if (this.saveTimeout) clearTimeout(this.saveTimeout)
-    try {
+    const rejectIfChanged = () => {
       if (
-        !pending.force &&
-        hasDocumentVersionConflict(
+        pending.force ||
+        !hasDocumentVersionConflict(
           this.loadedDocumentVersion,
           pending.documentVersion,
           this.document.version
         )
       ) {
-        this.send({
-          protocol: mpeProtocol,
-          version: mpeProtocolVersion,
-          type: 'mpe:saveResult',
-          requestId: pending.requestId,
-          payload: {
-            success: false,
-            code: 'document_changed',
-            message: 'The host document has changed',
-            canForce: true
-          }
-        })
+        return false
+      }
+      this.send({
+        protocol: mpeProtocol,
+        version: mpeProtocolVersion,
+        type: 'mpe:saveResult',
+        requestId: pending.requestId,
+        payload: {
+          success: false,
+          code: 'document_changed',
+          message: 'The host document has changed',
+          canForce: true
+        }
+      })
+      return true
+    }
+    try {
+      if (rejectIfChanged()) {
         return
       }
       const data = asRecord(asRecord(message.payload)?.data)
@@ -367,22 +398,25 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         })
       const sidecarUri = this.separatedConfigUri ?? this.sidecarUri()
       const separated = !!this.separatedConfigUri || !!(await this.readSidecar(sidecarUri))
+      if (rejectIfChanged()) {
+        return
+      }
       const next = separated ? splitPipelineAndConfig(data) : undefined
+      const original = this.document.getText()
+      const pipelineText = updatePipelineText(
+        original,
+        parsePipeline(original),
+        next?.pipeline ?? data
+      )
+      if (rejectIfChanged()) {
+        return
+      }
+      const edit = new vscode.WorkspaceEdit()
       if (next) {
-        await this.writeSidecar(sidecarUri, next.config)
+        this.appendSidecarEdit(edit, sidecarUri, next.config)
         this.separatedConfigUri = sidecarUri
       }
-      const original = this.document.getText()
-      const edits = updatePipelineText(original, parsePipeline(original), next?.pipeline ?? data)
-      const edit = new vscode.WorkspaceEdit()
-      edit.replace(
-        this.document.uri,
-        new vscode.Range(
-          this.document.positionAt(0),
-          this.document.positionAt(this.document.getText().length)
-        ),
-        edits
-      )
+      edit.replace(this.document.uri, documentRange(this.document), pipelineText)
       if (!(await vscode.workspace.applyEdit(edit)))
         throw new Error('VS Code rejected the document edit')
       this.loadedDocumentVersion = this.document.version
@@ -408,22 +442,17 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     }
   }
 
-  private async writeSidecar(uri: vscode.Uri, config: MpeConfig) {
+  private appendSidecarEdit(edit: vscode.WorkspaceEdit, uri: vscode.Uri, config: MpeConfig) {
     const text = stringifyMpeConfig(config)
     const open = vscode.workspace.textDocuments.find(doc => doc.uri.toString() === uri.toString())
     if (open) {
-      const edit = new vscode.WorkspaceEdit()
-      edit.replace(
-        uri,
-        new vscode.Range(open.positionAt(0), open.positionAt(open.getText().length)),
-        text
-      )
-      if (!(await vscode.workspace.applyEdit(edit))) {
-        throw new Error('VS Code rejected the MPE config edit')
-      }
+      edit.replace(uri, documentRange(open), text)
       return
     }
-    await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(text))
+    edit.createFile(uri, {
+      overwrite: true,
+      contents: new TextEncoder().encode(text)
+    })
   }
 
   private async openExternal(value: unknown) {

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -121,6 +121,7 @@ export class MpeService extends BaseService {
 class MpePanel implements vscode.Disposable {
   readonly panel: vscode.WebviewPanel
   private ready = false
+  private loadFailed = false
   private disposed = false
   private queue: MpeProtocolMessage[] = []
   private pendingSave?: { requestId: string; documentVersion: number; force: boolean }
@@ -217,6 +218,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private receive(value: unknown) {
     if (asRecord(value)?.builtin === 'mpe-host-ready') {
       this.ready = false
+      this.loadFailed = false
       this.pendingSave = undefined
       this.loadSeq += 1
       if (this.saveTimeout) clearTimeout(this.saveTimeout)
@@ -270,6 +272,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       if (this.disposed || seq !== this.loadSeq) {
         return
       }
+      this.loadFailed = true
       this.send({
         protocol: mpeProtocol,
         version: mpeProtocolVersion,
@@ -405,6 +408,20 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       return true
     }
     try {
+      if (this.loadFailed) {
+        this.send({
+          protocol: mpeProtocol,
+          version: mpeProtocolVersion,
+          type: 'mpe:saveResult',
+          requestId: pending.requestId,
+          payload: {
+            success: false,
+            code: 'save_blocked',
+            message: '请先加载成功再保存'
+          }
+        })
+        return
+      }
       if (rejectIfChanged()) {
         return
       }

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -14,6 +14,8 @@ import {
   isCompatibleMpeMessage,
   isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
+  isSeparatedMpeSidecar,
+  isSidecarNotFound,
   mergePipelineAndConfig,
   mpeProtocol,
   mpeProtocolVersion,
@@ -37,9 +39,9 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined
 }
 
-function errorCode(error: unknown) {
-  if (!error || typeof error !== 'object' || !('code' in error)) return 'save_failed'
-  return typeof error.code === 'string' ? error.code : 'save_failed'
+function errorCode(error: unknown, fallback = 'save_failed') {
+  if (!error || typeof error !== 'object' || !('code' in error)) return fallback
+  return typeof error.code === 'string' ? error.code : fallback
 }
 
 function documentRange(document: vscode.TextDocument) {
@@ -273,7 +275,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         version: mpeProtocolVersion,
         type: 'mpe:error',
         requestId,
-        payload: { code: 'invalid_pipeline', message: String(error) }
+        payload: { code: errorCode(error, 'invalid_pipeline'), message: String(error) }
       })
     }
   }
@@ -285,14 +287,24 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private async readSidecar(uri: vscode.Uri) {
     try {
       await vscode.workspace.fs.stat(uri)
-    } catch {
-      return undefined
+    } catch (error) {
+      if (isSidecarNotFound(error)) {
+        return { status: 'missing' as const }
+      }
+      logger.warn(`Failed to stat MPE config ${path.basename(uri.fsPath)}: ${String(error)}`)
+      return { status: 'invalid' as const, error }
     }
     try {
-      return parseMpeConfig((await vscode.workspace.openTextDocument(uri)).getText())
+      return {
+        status: 'ok' as const,
+        config: parseMpeConfig((await vscode.workspace.openTextDocument(uri)).getText())
+      }
     } catch (error) {
+      if (isSidecarNotFound(error)) {
+        return { status: 'missing' as const }
+      }
       logger.warn(`Failed to read MPE config ${path.basename(uri.fsPath)}: ${String(error)}`)
-      return undefined
+      return { status: 'invalid' as const, error }
     }
   }
 
@@ -305,7 +317,12 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       if (!isCurrentDocumentSnapshot(version, this.document.version)) {
         continue
       }
-      if (!sidecar) {
+      if (sidecar.status === 'invalid') {
+        throw Object.assign(new Error(`MPE config is invalid: ${String(sidecar.error)}`), {
+          code: 'invalid_config'
+        })
+      }
+      if (sidecar.status === 'missing') {
         this.separatedConfigUri = undefined
         return { data: pipeline, version }
       }
@@ -314,7 +331,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       return {
         data: mergePipelineAndConfig(
           pipeline,
-          sidecar,
+          sidecar.config,
           path.basename(this.document.fileName).replace(/\.(json|jsonc)$/i, ''),
           Object.keys(pipeline)
         ),
@@ -397,7 +414,8 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
           code: 'invalid_pipeline'
         })
       const sidecarUri = this.separatedConfigUri ?? this.sidecarUri()
-      const separated = !!this.separatedConfigUri || !!(await this.readSidecar(sidecarUri))
+      const sidecar = await this.readSidecar(sidecarUri)
+      const separated = isSeparatedMpeSidecar(!!this.separatedConfigUri, sidecar)
       if (rejectIfChanged()) {
         return
       }

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -8,14 +8,20 @@ import { isMaaAssistantArknights } from '../utils/fs'
 import { logger } from '../utils/logger'
 import { BaseService } from './context'
 import {
+  type MpeConfig,
   type MpeProtocolMessage,
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isMpeReadyForRequest,
+  mergePipelineAndConfig,
   mpeProtocol,
   mpeProtocolVersion,
+  mpeSidecarPath,
   normalizeExternalUrl,
+  parseMpeConfig,
   parsePipeline,
+  splitPipelineAndConfig,
+  stringifyMpeConfig,
   updatePipelineText
 } from './mpeProtocol'
 import { interfaceService } from './registry'
@@ -111,6 +117,7 @@ class MpePanel implements vscode.Disposable {
   private queue: MpeProtocolMessage[] = []
   private pendingSave?: { requestId: string; documentVersion: number; force: boolean }
   private loadedDocumentVersion?: number
+  private separatedConfigUri?: vscode.Uri
   private saveTimeout?: ReturnType<typeof setTimeout>
   private requestCounter = 0
   private readonly disposables: vscode.Disposable[] = []
@@ -189,7 +196,7 @@ class MpePanel implements vscode.Disposable {
         host: { id: 'mse', name: 'MSE', repositoryUrl }
       }
     }
-    this.panel.webview.html = `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{box-sizing:border-box;margin:0;padding:0;width:100%;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style></head><body><iframe id="mpe" src="${frameUrl}" title="MaaPipelineEditor"></iframe><script nonce="${nonce}">
+    this.panel.webview.html = `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${csp}"><style>html,body{box-sizing:border-box;margin:0;padding:0;width:100%;height:100%;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style></head><body><iframe id="mpe" src="${frameUrl}" title="MaaPipelineEditor" allow="clipboard-read; clipboard-write; clipboard-sanitized-write"></iframe><script nonce="${nonce}">
 const api=acquireVsCodeApi(), frame=document.getElementById('mpe');
 window.addEventListener('message',e=>{if(e.source===frame.contentWindow&&e.origin==='${origin}'&&e.data?.protocol==='mpe-embed')api.postMessage(e.data);else if(e.source!==frame.contentWindow)frame.contentWindow?.postMessage(e.data,'${origin}')});
 frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
@@ -217,10 +224,10 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
           return
         this.ready = true
         this.flush()
-        this.load(`mse-load-${Date.now()}-${++this.requestCounter}`)
+        void this.load(`mse-load-${Date.now()}-${++this.requestCounter}`)
         break
       case 'mpe:reloadRequest':
-        this.load(message.requestId)
+        void this.load(message.requestId)
         break
       case 'mpe:saveRequest':
         this.requestSave(message)
@@ -234,9 +241,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     }
   }
 
-  private load(requestId?: string) {
+  private async load(requestId?: string) {
     try {
-      const data = parsePipeline(this.document.getText())
+      const data = await this.pipelineSnapshot()
       this.loadedDocumentVersion = this.document.version
       this.send({
         protocol: mpeProtocol,
@@ -254,6 +261,42 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         payload: { code: 'invalid_pipeline', message: String(error) }
       })
     }
+  }
+
+  private sidecarUri() {
+    return vscode.Uri.file(mpeSidecarPath(this.document.uri.fsPath))
+  }
+
+  private async readSidecar(uri: vscode.Uri) {
+    try {
+      await vscode.workspace.fs.stat(uri)
+    } catch {
+      return undefined
+    }
+    try {
+      return parseMpeConfig((await vscode.workspace.openTextDocument(uri)).getText())
+    } catch (error) {
+      logger.warn(`Failed to read MPE config ${path.basename(uri.fsPath)}: ${String(error)}`)
+      return undefined
+    }
+  }
+
+  private async pipelineSnapshot() {
+    const pipeline = parsePipeline(this.document.getText())
+    const sidecarUri = this.sidecarUri()
+    const sidecar = await this.readSidecar(sidecarUri)
+    if (!sidecar) {
+      this.separatedConfigUri = undefined
+      return pipeline
+    }
+    this.separatedConfigUri = sidecarUri
+    // mpe:loadPipeline only accepts a combined pipeline object, so merge the sidecar here.
+    return mergePipelineAndConfig(
+      pipeline,
+      sidecar,
+      path.basename(this.document.fileName).replace(/\.(json|jsonc)$/i, ''),
+      Object.keys(pipeline)
+    )
   }
 
   private requestSave(message: MpeProtocolMessage) {
@@ -322,8 +365,15 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         throw Object.assign(new Error('MPE returned invalid Pipeline data'), {
           code: 'invalid_pipeline'
         })
+      const sidecarUri = this.separatedConfigUri ?? this.sidecarUri()
+      const separated = !!this.separatedConfigUri || !!(await this.readSidecar(sidecarUri))
+      const next = separated ? splitPipelineAndConfig(data) : undefined
+      if (next) {
+        await this.writeSidecar(sidecarUri, next.config)
+        this.separatedConfigUri = sidecarUri
+      }
       const original = this.document.getText()
-      const edits = updatePipelineText(original, parsePipeline(original), data)
+      const edits = updatePipelineText(original, parsePipeline(original), next?.pipeline ?? data)
       const edit = new vscode.WorkspaceEdit()
       edit.replace(
         this.document.uri,
@@ -356,6 +406,24 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         }
       })
     }
+  }
+
+  private async writeSidecar(uri: vscode.Uri, config: MpeConfig) {
+    const text = stringifyMpeConfig(config)
+    const open = vscode.workspace.textDocuments.find(doc => doc.uri.toString() === uri.toString())
+    if (open) {
+      const edit = new vscode.WorkspaceEdit()
+      edit.replace(
+        uri,
+        new vscode.Range(open.positionAt(0), open.positionAt(open.getText().length)),
+        text
+      )
+      if (!(await vscode.workspace.applyEdit(edit))) {
+        throw new Error('VS Code rejected the MPE config edit')
+      }
+      return
+    }
+    await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(text))
   }
 
   private async openExternal(value: unknown) {

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -79,14 +79,39 @@ export function parsePipeline(text: string) {
 
 export function parseMpeConfig(text: string): MpeConfig {
   const data = parseJsonObject(text, 'MPE config')
-  return {
-    file_config: { filename: '', ...asRecord(data.file_config) },
-    node_configs: asRecord(data.node_configs) ?? {},
-    ...(asRecord(data.external_nodes) ? { external_nodes: asRecord(data.external_nodes) } : {}),
-    ...(asRecord(data.anchor_nodes) ? { anchor_nodes: asRecord(data.anchor_nodes) } : {}),
-    ...(asRecord(data.sticker_nodes) ? { sticker_nodes: asRecord(data.sticker_nodes) } : {}),
-    ...(asRecord(data.group_nodes) ? { group_nodes: asRecord(data.group_nodes) } : {})
+
+  const fileConfig = asRecord(data.file_config)
+  if (!fileConfig) {
+    throw new Error('MPE config file_config must be an object')
   }
+
+  const nodeConfigs = asRecord(data.node_configs)
+  if (!nodeConfigs) {
+    throw new Error('MPE config node_configs must be an object')
+  }
+
+  const config: MpeConfig = {
+    file_config: { filename: '', ...fileConfig },
+    node_configs: nodeConfigs
+  }
+
+  const specials = [
+    [externalMarkPrefix, data.external_nodes, 'external_nodes'] as const,
+    [anchorMarkPrefix, data.anchor_nodes, 'anchor_nodes'] as const,
+    [stickerMarkPrefix, data.sticker_nodes, 'sticker_nodes'] as const,
+    [groupMarkPrefix, data.group_nodes, 'group_nodes'] as const
+  ]
+
+  for (const [prefix, nodes, field] of specials) {
+    if (nodes && !asRecord(nodes)) {
+      throw new Error(`MPE config ${field} must be an object`)
+    }
+    if (nodes) {
+      config[field as keyof MpeConfig] = nodes
+    }
+  }
+
+  return config
 }
 
 export type MpeSidecarRead =

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -6,8 +6,43 @@ import {
   parse,
   printParseErrorCode
 } from 'jsonc-parser'
+import * as path from 'node:path'
 
 const formatting: FormattingOptions = { tabSize: 2, insertSpaces: true, eol: '\n' }
+
+const configMark = '$__mpe_code'
+const configMarkPrefix = '$__mpe_config_'
+const externalMarkPrefix = '$__mpe_external_'
+const anchorMarkPrefix = '$__mpe_anchor_'
+const stickerMarkPrefix = '$__mpe_sticker_'
+const groupMarkPrefix = '$__mpe_group_'
+
+export type MpeConfig = {
+  file_config: Record<string, unknown> & { filename?: string }
+  node_configs: Record<string, unknown>
+  external_nodes?: Record<string, unknown>
+  anchor_nodes?: Record<string, unknown>
+  sticker_nodes?: Record<string, unknown>
+  group_nodes?: Record<string, unknown>
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function parseJsonObject(text: string, label: string) {
+  const errors: ParseError[] = []
+  const data = parse(text, errors, { allowTrailingComma: true, disallowComments: false })
+  if (errors.length || !data || typeof data !== 'object' || Array.isArray(data)) {
+    const detail = errors[0]
+      ? printParseErrorCode(errors[0].error)
+      : `${label} must be a JSON object`
+    throw new Error(`${label} JSONC parse failed: ${detail}`)
+  }
+  return data as Record<string, unknown>
+}
 
 export const mpeProtocol = 'mpe-embed'
 export const mpeProtocolVersion = '1.3.0'
@@ -39,15 +74,253 @@ export function isMpeReadyForRequest(value: unknown, requestId: string) {
 }
 
 export function parsePipeline(text: string) {
-  const errors: ParseError[] = []
-  const data = parse(text, errors, { allowTrailingComma: true, disallowComments: false })
-  if (errors.length || !data || typeof data !== 'object' || Array.isArray(data)) {
-    const detail = errors[0]
-      ? printParseErrorCode(errors[0].error)
-      : 'Pipeline must be a JSON object'
-    throw new Error(`Pipeline JSONC parse failed: ${detail}`)
+  return parseJsonObject(text, 'Pipeline')
+}
+
+export function parseMpeConfig(text: string): MpeConfig {
+  const data = parseJsonObject(text, 'MPE config')
+  return {
+    file_config: { filename: '', ...asRecord(data.file_config) },
+    node_configs: asRecord(data.node_configs) ?? {},
+    ...(asRecord(data.external_nodes) ? { external_nodes: asRecord(data.external_nodes) } : {}),
+    ...(asRecord(data.anchor_nodes) ? { anchor_nodes: asRecord(data.anchor_nodes) } : {}),
+    ...(asRecord(data.sticker_nodes) ? { sticker_nodes: asRecord(data.sticker_nodes) } : {}),
+    ...(asRecord(data.group_nodes) ? { group_nodes: asRecord(data.group_nodes) } : {})
   }
-  return data as Record<string, unknown>
+}
+
+export function mpeSidecarPath(pipelinePath: string) {
+  const baseName = path.basename(pipelinePath).replace(/\.(json|jsonc)$/i, '')
+  return path.join(path.dirname(pipelinePath), `.${baseName}.mpe.json`)
+}
+
+function isLegacyConfigKey(key: string) {
+  return key.startsWith('__mpe_config_') || key.startsWith('__yamaape_config_')
+}
+
+function extractNodeName(key: string, prefix: string, fileName: string) {
+  const withoutPrefix = key.substring(prefix.length)
+  const suffix = `_${fileName}`
+  if (fileName && withoutPrefix.endsWith(suffix)) {
+    return withoutPrefix.slice(0, -suffix.length)
+  }
+  return withoutPrefix
+}
+
+function buildMpeCode(nodeData: unknown) {
+  const rec = asRecord(nodeData)
+  if (rec?.position) {
+    const mpeCode: Record<string, unknown> = { position: rec.position }
+    if (rec.handleDirection) {
+      mpeCode.handleDirection = rec.handleDirection
+    }
+    if (Array.isArray(rec.extra_positions) && rec.extra_positions.length > 0) {
+      mpeCode.extra_positions = rec.extra_positions
+    }
+    return mpeCode
+  }
+  const wrapped = asRecord(rec?.[configMark])
+  return wrapped ?? { position: { x: 0, y: 0 } }
+}
+
+function extractNodeConfig(mpeCode: unknown) {
+  const rec = asRecord(mpeCode)
+  if (!rec?.position) {
+    return null
+  }
+  const nodeConfig: Record<string, unknown> = { position: rec.position }
+  if (rec.handleDirection) {
+    nodeConfig.handleDirection = rec.handleDirection
+  }
+  if (Array.isArray(rec.extra_positions)) {
+    nodeConfig.extra_positions = rec.extra_positions
+  }
+  return nodeConfig
+}
+
+export function mergePipelineAndConfig(
+  pipeline: Record<string, unknown>,
+  config: MpeConfig,
+  fileName?: string,
+  keyOrder?: string[]
+) {
+  const actualFileName = fileName || String(config.file_config.filename || '未命名')
+  const merged: Record<string, unknown> = {
+    [configMarkPrefix + actualFileName]: {
+      [configMark]: {
+        ...config.file_config,
+        filename: actualFileName
+      }
+    }
+  }
+  const added = new Set<string>([configMarkPrefix + actualFileName])
+
+  const specials = [
+    [externalMarkPrefix, config.external_nodes] as const,
+    [anchorMarkPrefix, config.anchor_nodes] as const,
+    [stickerMarkPrefix, config.sticker_nodes] as const,
+    [groupMarkPrefix, config.group_nodes] as const
+  ]
+
+  const specialByName = specials.map(([prefix, nodes]) => {
+    const map = new Map<string, unknown>()
+    if (nodes) {
+      for (const [nodeName, nodeData] of Object.entries(nodes)) {
+        map.set(nodeName, nodeData)
+      }
+    }
+    return { prefix, map }
+  })
+
+  const addSpecial = (prefix: string, nodeName: string, data: unknown) => {
+    const key = prefix + nodeName + '_' + actualFileName
+    if (added.has(key)) {
+      return
+    }
+    merged[key] = {
+      [configMark]:
+        prefix === stickerMarkPrefix || prefix === groupMarkPrefix
+          ? (asRecord(data) ?? { position: { x: 0, y: 0 } })
+          : buildMpeCode(data)
+    }
+    added.add(key)
+  }
+
+  const addNormal = (key: string, value: unknown) => {
+    const nodeConfig = asRecord(config.node_configs[key])
+    if (nodeConfig?.position) {
+      merged[key] = {
+        ...asRecord(value),
+        [configMark]: buildMpeCode(nodeConfig)
+      }
+    } else {
+      merged[key] = value
+    }
+    added.add(key)
+  }
+
+  const keys = keyOrder?.length ? keyOrder : Object.keys(pipeline)
+  for (const originalKey of keys) {
+    if (originalKey.startsWith(configMarkPrefix) || isLegacyConfigKey(originalKey)) {
+      continue
+    }
+
+    const special = specialByName.find(item => originalKey.startsWith(item.prefix))
+    if (special) {
+      const nodeName = extractNodeName(originalKey, special.prefix, actualFileName)
+      const nodeData = special.map.get(nodeName)
+      if (nodeData !== undefined) {
+        addSpecial(special.prefix, nodeName, nodeData)
+      }
+      continue
+    }
+
+    if (pipeline[originalKey] !== undefined) {
+      addNormal(originalKey, pipeline[originalKey])
+    }
+  }
+
+  for (const { prefix, map } of specialByName) {
+    for (const [nodeName, nodeData] of map) {
+      addSpecial(prefix, nodeName, nodeData)
+    }
+  }
+
+  if (keyOrder?.length) {
+    for (const [key, value] of Object.entries(pipeline)) {
+      if (!added.has(key) && !key.startsWith(configMarkPrefix) && !isLegacyConfigKey(key)) {
+        addNormal(key, value)
+      }
+    }
+  }
+
+  return merged
+}
+
+export function splitPipelineAndConfig(pipelineObj: Record<string, unknown>): {
+  pipeline: Record<string, unknown>
+  config: MpeConfig
+} {
+  const pipeline: Record<string, unknown> = {}
+  const config: MpeConfig = {
+    file_config: { filename: '' },
+    node_configs: {},
+    external_nodes: {},
+    anchor_nodes: {},
+    sticker_nodes: {},
+    group_nodes: {}
+  }
+
+  for (const [key, value] of Object.entries(pipelineObj)) {
+    if (!key.startsWith(configMarkPrefix)) {
+      continue
+    }
+    const fileConfig = asRecord(asRecord(value)?.[configMark])
+    if (fileConfig) {
+      config.file_config = {
+        ...fileConfig,
+        filename: typeof fileConfig.filename === 'string' ? fileConfig.filename : ''
+      }
+    }
+  }
+
+  const filename = String(config.file_config.filename || '')
+  const specials = [
+    [externalMarkPrefix, 'external_nodes'] as const,
+    [anchorMarkPrefix, 'anchor_nodes'] as const,
+    [stickerMarkPrefix, 'sticker_nodes'] as const,
+    [groupMarkPrefix, 'group_nodes'] as const
+  ]
+
+  for (const [key, value] of Object.entries(pipelineObj)) {
+    if (key.startsWith(configMarkPrefix)) {
+      continue
+    }
+
+    const rec = asRecord(value)
+    const special = specials.find(([prefix]) => key.startsWith(prefix))
+    if (special) {
+      const [prefix, field] = special
+      const nodeName = extractNodeName(key, prefix, filename)
+      const mpeCode = rec?.[configMark]
+      if (field === 'sticker_nodes' || field === 'group_nodes') {
+        config[field]![nodeName] = mpeCode ?? { position: { x: 0, y: 0 } }
+      } else {
+        config[field]![nodeName] = extractNodeConfig(mpeCode) ?? { position: { x: 0, y: 0 } }
+      }
+      continue
+    }
+
+    const nodeConfig = extractNodeConfig(rec?.[configMark])
+    if (nodeConfig) {
+      config.node_configs[key] = nodeConfig
+    }
+    if (rec) {
+      const { [configMark]: _, ...pureNode } = rec
+      pipeline[key] = pureNode
+    } else {
+      pipeline[key] = value
+    }
+  }
+
+  if (Object.keys(config.external_nodes!).length === 0) {
+    delete config.external_nodes
+  }
+  if (Object.keys(config.anchor_nodes!).length === 0) {
+    delete config.anchor_nodes
+  }
+  if (Object.keys(config.sticker_nodes!).length === 0) {
+    delete config.sticker_nodes
+  }
+  if (Object.keys(config.group_nodes!).length === 0) {
+    delete config.group_nodes
+  }
+
+  return { pipeline, config }
+}
+
+export function stringifyMpeConfig(config: MpeConfig) {
+  return JSON.stringify(config, null, formatting.tabSize) + formatting.eol
 }
 
 export function updatePipelineText(

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -348,6 +348,10 @@ export function hasDocumentVersionConflict(
   )
 }
 
+export function isCurrentDocumentSnapshot(readVersion: number, currentVersion: number) {
+  return readVersion === currentVersion
+}
+
 export function normalizeExternalUrl(value: unknown): string | null {
   if (typeof value !== 'string') return null
 

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -89,6 +89,20 @@ export function parseMpeConfig(text: string): MpeConfig {
   }
 }
 
+export type MpeSidecarRead =
+  | { status: 'missing' }
+  | { status: 'ok'; config: MpeConfig }
+  | { status: 'invalid'; error: unknown }
+
+export function isSidecarNotFound(error: unknown) {
+  if (!error || typeof error !== 'object' || !('code' in error)) return false
+  return error.code === 'FileNotFound' || error.code === 'ENOENT'
+}
+
+export function isSeparatedMpeSidecar(alreadySeparated: boolean, sidecar: MpeSidecarRead) {
+  return alreadySeparated || sidecar.status !== 'missing'
+}
+
 export function mpeSidecarPath(pipelinePath: string) {
   const baseName = path.basename(pipelinePath).replace(/\.(json|jsonc)$/i, '')
   return path.join(path.dirname(pipelinePath), `.${baseName}.mpe.json`)

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -73,6 +73,20 @@ export function isMpeReadyForRequest(value: unknown, requestId: string) {
   )
 }
 
+export type MpeLoadAuth = 'idle' | 'loaded' | 'failed'
+
+export function beginMpeLoad(): MpeLoadAuth {
+  return 'idle'
+}
+
+export function finishMpeLoad(ok: boolean): MpeLoadAuth {
+  return ok ? 'loaded' : 'failed'
+}
+
+export function isMpeSaveAllowed(auth: MpeLoadAuth) {
+  return auth === 'loaded'
+}
+
 export function parsePipeline(text: string) {
   return parseJsonObject(text, 'Pipeline')
 }
@@ -95,23 +109,25 @@ export function parseMpeConfig(text: string): MpeConfig {
     node_configs: nodeConfigs
   }
 
-  const specials = [
-    [externalMarkPrefix, data.external_nodes, 'external_nodes'] as const,
-    [anchorMarkPrefix, data.anchor_nodes, 'anchor_nodes'] as const,
-    [stickerMarkPrefix, data.sticker_nodes, 'sticker_nodes'] as const,
-    [groupMarkPrefix, data.group_nodes, 'group_nodes'] as const
-  ]
-
-  for (const [prefix, nodes, field] of specials) {
-    if (nodes && !asRecord(nodes)) {
-      throw new Error(`MPE config ${field} must be an object`)
-    }
-    if (nodes) {
-      config[field as keyof MpeConfig] = nodes
-    }
-  }
+  const externalNodes = optionalNodeMap(data.external_nodes, 'external_nodes')
+  const anchorNodes = optionalNodeMap(data.anchor_nodes, 'anchor_nodes')
+  const stickerNodes = optionalNodeMap(data.sticker_nodes, 'sticker_nodes')
+  const groupNodes = optionalNodeMap(data.group_nodes, 'group_nodes')
+  if (externalNodes) config.external_nodes = externalNodes
+  if (anchorNodes) config.anchor_nodes = anchorNodes
+  if (stickerNodes) config.sticker_nodes = stickerNodes
+  if (groupNodes) config.group_nodes = groupNodes
 
   return config
+}
+
+function optionalNodeMap(value: unknown, field: string) {
+  if (value === undefined) return undefined
+  const nodes = asRecord(value)
+  if (!nodes) {
+    throw new Error(`MPE config ${field} must be an object`)
+  }
+  return nodes
 }
 
 export type MpeSidecarRead =

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -167,6 +167,21 @@ test('treats only a missing sidecar as integrated mode', () => {
   assert.equal(isSeparatedMpeSidecar(false, invalid), true)
 })
 
+test('rejects sidecar configs with wrong field types', () => {
+  assert.throws(
+    () => parseMpeConfig('{"file_config": [], "node_configs": {}}'),
+    /file_config must be an object/
+  )
+  assert.throws(
+    () => parseMpeConfig('{"file_config": {}, "node_configs": "conflict"}'),
+    /node_configs must be an object/
+  )
+  assert.throws(
+    () => parseMpeConfig('{"file_config": {}, "node_configs": {}, "external_nodes": []}'),
+    /external_nodes must be an object/
+  )
+})
+
 test('parses a separated MPE config file', () => {
   const config = parseMpeConfig(`{
     // layout
@@ -259,6 +274,15 @@ test('MPE host loads and writes the separated sidecar config', () => {
   assert.match(source, /appendSidecarEdit/)
   assert.match(source, /status: 'missing' as const/)
   assert.match(source, /status: 'invalid' as const/)
+})
+
+test('MPE host blocks save after a failed sidecar load', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /this\.loadFailed = true/)
+  assert.match(source, /if \(this\.loadFailed\)/)
+  assert.match(source, /code: 'save_blocked'/)
+  assert.match(source, /请先加载成功再保存/)
 })
 
 test('MPE host binds the loaded version to the parsed snapshot', () => {

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -1,15 +1,21 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import * as path from 'node:path'
 import test from 'node:test'
 
 import {
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isMpeReadyForRequest,
+  mergePipelineAndConfig,
   mpeProtocol,
   mpeProtocolVersion,
+  mpeSidecarPath,
   normalizeExternalUrl,
+  parseMpeConfig,
   parsePipeline,
+  splitPipelineAndConfig,
+  stringifyMpeConfig,
   updatePipelineText
 } from '../src/service/mpeProtocol.ts'
 
@@ -114,4 +120,107 @@ test('MPE document lifecycle closes the underlying webview panel', () => {
     source,
     /close\(\) \{\r?\n[ \t]{4}if \(!this\.disposed\) this\.panel\.dispose\(\)\r?\n[ \t]{2}\}/
   )
+})
+
+test('MPE iframe delegates clipboard permissions to the embedded editor', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /allow="clipboard-read; clipboard-write; clipboard-sanitized-write"/)
+})
+
+test('resolves the hidden MPE sidecar next to a pipeline file', () => {
+  const pipelineJson = path.join('/proj', 'pipeline', 'fight.json')
+  const pipelineJsonc = path.join('/proj', 'pipeline', 'fight.jsonc')
+  const sidecar = path.join('/proj', 'pipeline', '.fight.mpe.json')
+
+  assert.equal(mpeSidecarPath(pipelineJson), sidecar)
+  assert.equal(mpeSidecarPath(pipelineJsonc), sidecar)
+})
+
+test('parses a separated MPE config file', () => {
+  const config = parseMpeConfig(`{
+    // layout
+    "file_config": { "filename": "fight" },
+    "node_configs": { "Start": { "position": { "x": 10, "y": 20 } } },
+  }`)
+
+  assert.equal(config.file_config.filename, 'fight')
+  assert.deepEqual(config.node_configs.Start, { position: { x: 10, y: 20 } })
+})
+
+test('merges a sidecar config into pipeline nodes for MPE load', () => {
+  const pipeline = {
+    Start: { next: ['End'] },
+    End: {}
+  }
+  const merged = mergePipelineAndConfig(
+    pipeline,
+    {
+      file_config: { filename: 'fight', coordinateMode: 'absolute-v1' },
+      node_configs: {
+        Start: { position: { x: 12, y: 34 }, handleDirection: 'horizontal' },
+        End: { position: { x: 56, y: 78 }, extra_positions: [{ x: 1, y: 2 }] }
+      },
+      external_nodes: {
+        Shared: { position: { x: 9, y: 8 } }
+      }
+    },
+    'fight',
+    Object.keys(pipeline)
+  )
+
+  assert.deepEqual(merged['$__mpe_config_fight'], {
+    $__mpe_code: { filename: 'fight', coordinateMode: 'absolute-v1' }
+  })
+  assert.deepEqual(merged.Start, {
+    next: ['End'],
+    $__mpe_code: { position: { x: 12, y: 34 }, handleDirection: 'horizontal' }
+  })
+  assert.deepEqual(merged.End, {
+    $__mpe_code: {
+      position: { x: 56, y: 78 },
+      extra_positions: [{ x: 1, y: 2 }]
+    }
+  })
+  assert.deepEqual(merged['$__mpe_external_Shared_fight'], {
+    $__mpe_code: { position: { x: 9, y: 8 } }
+  })
+})
+
+test('splits MPE save data back into a clean pipeline and sidecar config', () => {
+  const { pipeline, config } = splitPipelineAndConfig({
+    $__mpe_config_fight: {
+      $__mpe_code: { filename: 'fight', coordinateMode: 'absolute-v1' }
+    },
+    Start: {
+      next: ['End'],
+      $__mpe_code: { position: { x: 12, y: 34 }, handleDirection: 'horizontal' }
+    },
+    End: {},
+    $__mpe_sticker_Note_fight: {
+      $__mpe_code: { position: { x: 1, y: 2 }, text: 'note' }
+    }
+  })
+
+  assert.deepEqual(pipeline, {
+    Start: { next: ['End'] },
+    End: {}
+  })
+  assert.deepEqual(config.file_config, { filename: 'fight', coordinateMode: 'absolute-v1' })
+  assert.deepEqual(config.node_configs.Start, {
+    position: { x: 12, y: 34 },
+    handleDirection: 'horizontal'
+  })
+  assert.equal(config.node_configs.End, undefined)
+  assert.deepEqual(config.sticker_nodes?.Note, { position: { x: 1, y: 2 }, text: 'note' })
+  assert.match(stringifyMpeConfig(config), /"filename": "fight"/)
+})
+
+test('MPE host loads and writes the separated sidecar config', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /readSidecar/)
+  assert.match(source, /mergePipelineAndConfig/)
+  assert.match(source, /splitPipelineAndConfig/)
+  assert.match(source, /writeSidecar/)
 })

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test'
 import {
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
+  isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
   mergePipelineAndConfig,
   mpeProtocol,
@@ -49,10 +50,16 @@ test('detects document changes before and during an MPE save', () => {
   assert.equal(hasDocumentVersionConflict(undefined, 3, 3), false)
 })
 
+test('accepts a snapshot only when it matches the current document version', () => {
+  assert.equal(isCurrentDocumentSnapshot(3, 3), true)
+  assert.equal(isCurrentDocumentSnapshot(3, 4), false)
+})
+
 test('delegates document conflict choices to the MPE protocol', () => {
   const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
 
-  assert.match(source, /!pending\.force/)
+  assert.match(source, /pending\.force/)
+  assert.match(source, /rejectIfChanged/)
   assert.match(source, /code: 'document_changed'/)
   assert.match(source, /canForce: true/)
   assert.doesNotMatch(source, /showWarningMessage\(/)
@@ -222,5 +229,26 @@ test('MPE host loads and writes the separated sidecar config', () => {
   assert.match(source, /readSidecar/)
   assert.match(source, /mergePipelineAndConfig/)
   assert.match(source, /splitPipelineAndConfig/)
-  assert.match(source, /writeSidecar/)
+  assert.match(source, /appendSidecarEdit/)
+})
+
+test('MPE host binds the loaded version to the parsed snapshot', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /isCurrentDocumentSnapshot\(version, this\.document\.version\)/)
+  assert.match(source, /loadedDocumentVersion = snapshot\.version/)
+  assert.match(source, /seq !== this\.loadSeq/)
+})
+
+test('MPE host writes pipeline and sidecar in one WorkspaceEdit', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /appendSidecarEdit\(edit, sidecarUri, next\.config\)/)
+  assert.match(source, /edit\.createFile\(uri, \{/)
+  assert.match(
+    source,
+    /edit\.replace\(this\.document\.uri, documentRange\(this\.document\), pipelineText\)/
+  )
+  assert.doesNotMatch(source, /workspace\.fs\.writeFile/)
+  assert.doesNotMatch(source, /writeSidecar/)
 })

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -8,6 +8,8 @@ import {
   isCompatibleMpeMessage,
   isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
+  isSeparatedMpeSidecar,
+  isSidecarNotFound,
   mergePipelineAndConfig,
   mpeProtocol,
   mpeProtocolVersion,
@@ -144,6 +146,27 @@ test('resolves the hidden MPE sidecar next to a pipeline file', () => {
   assert.equal(mpeSidecarPath(pipelineJsonc), sidecar)
 })
 
+test('treats only a missing sidecar as integrated mode', () => {
+  assert.equal(isSidecarNotFound({ code: 'FileNotFound' }), true)
+  assert.equal(isSidecarNotFound({ code: 'ENOENT' }), true)
+  assert.equal(isSidecarNotFound({ code: 'NoPermissions' }), false)
+  assert.equal(isSidecarNotFound({ code: 'Unavailable' }), false)
+  assert.equal(isSidecarNotFound(new Error('MPE config JSONC parse failed')), false)
+  assert.equal(isSidecarNotFound(undefined), false)
+
+  const missing = { status: 'missing' as const }
+  const ok = {
+    status: 'ok' as const,
+    config: { file_config: { filename: 'fight' }, node_configs: {} }
+  }
+  const invalid = { status: 'invalid' as const, error: new Error('conflict') }
+
+  assert.equal(isSeparatedMpeSidecar(false, missing), false)
+  assert.equal(isSeparatedMpeSidecar(true, missing), true)
+  assert.equal(isSeparatedMpeSidecar(false, ok), true)
+  assert.equal(isSeparatedMpeSidecar(false, invalid), true)
+})
+
 test('parses a separated MPE config file', () => {
   const config = parseMpeConfig(`{
     // layout
@@ -227,9 +250,15 @@ test('MPE host loads and writes the separated sidecar config', () => {
   const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
 
   assert.match(source, /readSidecar/)
+  assert.match(source, /isSidecarNotFound/)
+  assert.match(source, /isSeparatedMpeSidecar/)
+  assert.match(source, /code: 'invalid_config'/)
+  assert.match(source, /errorCode\(error, 'invalid_pipeline'\)/)
   assert.match(source, /mergePipelineAndConfig/)
   assert.match(source, /splitPipelineAndConfig/)
   assert.match(source, /appendSidecarEdit/)
+  assert.match(source, /status: 'missing' as const/)
+  assert.match(source, /status: 'invalid' as const/)
 })
 
 test('MPE host binds the loaded version to the parsed snapshot', () => {

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -4,10 +4,13 @@ import * as path from 'node:path'
 import test from 'node:test'
 
 import {
+  beginMpeLoad,
+  finishMpeLoad,
   hasDocumentVersionConflict,
   isCompatibleMpeMessage,
   isCurrentDocumentSnapshot,
   isMpeReadyForRequest,
+  isMpeSaveAllowed,
   isSeparatedMpeSidecar,
   isSidecarNotFound,
   mergePipelineAndConfig,
@@ -180,6 +183,10 @@ test('rejects sidecar configs with wrong field types', () => {
     () => parseMpeConfig('{"file_config": {}, "node_configs": {}, "external_nodes": []}'),
     /external_nodes must be an object/
   )
+  assert.throws(
+    () => parseMpeConfig('{"file_config": {}, "node_configs": {}, "sticker_nodes": null}'),
+    /sticker_nodes must be an object/
+  )
 })
 
 test('parses a separated MPE config file', () => {
@@ -276,11 +283,27 @@ test('MPE host loads and writes the separated sidecar config', () => {
   assert.match(source, /status: 'invalid' as const/)
 })
 
-test('MPE host blocks save after a failed sidecar load', () => {
+test('blocks MPE save until a host load succeeds', () => {
+  let auth = beginMpeLoad()
+  assert.equal(isMpeSaveAllowed(auth), false)
+
+  auth = finishMpeLoad(false)
+  assert.equal(isMpeSaveAllowed(auth), false)
+
+  auth = finishMpeLoad(true)
+  assert.equal(isMpeSaveAllowed(auth), true)
+
+  auth = beginMpeLoad()
+  assert.equal(isMpeSaveAllowed(auth), false)
+})
+
+test('MPE host only accepts save after a successful load', () => {
   const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
 
-  assert.match(source, /this\.loadFailed = true/)
-  assert.match(source, /if \(this\.loadFailed\)/)
+  assert.match(source, /this\.loadAuth = beginMpeLoad\(\)/)
+  assert.match(source, /this\.loadAuth = finishMpeLoad\(true\)/)
+  assert.match(source, /this\.loadAuth = finishMpeLoad\(false\)/)
+  assert.match(source, /!isMpeSaveAllowed\(this\.loadAuth\)/)
   assert.match(source, /code: 'save_blocked'/)
   assert.match(source, /请先加载成功再保存/)
 })


### PR DESCRIPTION
## Summary

修复 MPE 嵌入面板的两个用户反馈：剪贴板被 Webview Permissions-Policy 拦截，以及打开 Pipeline 时不读取同目录 `.mpe.json` 配置。

### 剪贴板 `NotAllowedError`

MPE 在跨源 iframe 里直接调用 `navigator.clipboard.writeText`。VS Code Webview 外层已经授予剪贴板权限，但内层 iframe 没有 `allow`，浏览器会拒绝 Clipboard API。

现在 iframe 下放：

- `clipboard-read`
- `clipboard-write`
- `clipboard-sanitized-write`

### 打开 Pipeline 不读 `.mpe.json`

MPE 独立打开文件时会读取同目录 `.{文件名}.mpe.json`（节点位置、便签等）。嵌入协议 `mpe:loadPipeline` 只接收一份合并后的 pipeline 对象，宿主之前只传了文本内容，画布布局会丢失。

现在对齐 MPE LocalBridge：

- 打开 / 从 MSE 同步：sidecar 存在则先合并再交给 MPE
- 保存：分离模式下把 `$__mpe_*` 拆回 sidecar，Pipeline 文件保持干净
- 没有 sidecar 时行为不变（按集成模式写回）