### PR TITLE
fix(mpe): support embedded cross-file navigation

### DIFF
--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -135,7 +135,9 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 未成功加载完成前禁止保存（含加载进行中和加载失败），避免空画布覆盖 Pipeline；加载成功后恢复保存
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖
-- MPE iframe 使用 v1.3.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择
+- MPE iframe 使用 v1.4.0 协议；外部链接由宿主校验后交给 VS Code 打开，文档冲突由 MPE 提供同步/强制覆盖选择
+- iframe 内的 External 节点跳转由 MSE 使用现有 Pipeline 索引解析；若有多个定义先选择目标，再同时保留目标 JSON 标签和对应 MPE 面板，并在画布加载成功后选中、定位目标节点
+- iframe 内不提供 Anchor 跳转，但会把现有 Anchor 索引中的定义文件与节点作为只读上下文传给 MPE 展示
 - 嵌入 iframe 会向 MPE 下放剪贴板读写权限，使复制/粘贴走浏览器 Clipboard API 而不是被 Webview Permissions-Policy 拦截
 - MPE 地址可通过 `maa.pipelineEditorUrl` 配置，生产地址要求 HTTPS，本机 localhost 开发地址允许 HTTP
 

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -29,8 +29,8 @@ src/
     ├── shortcut.ts           # ShortcutService — 全局快捷键目标租约和跨窗口请求转发
     ├── native.ts             # NativeService — MaaFramework 二进制管理
     ├── server.ts             # ServerService — RPC 连接管理
-    ├── mpe.ts                # MPE iframe 面板、握手、版本稳定快照、损坏 sidecar 拒绝加载、未成功加载禁止保存、sidecar 与 Pipeline 同一次保存
-    ├── mpeProtocol.ts        # mpe-embed 协议校验、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 缺失/损坏/字段类型判定、加载授权
+    ├── mpe.ts                # MPE iframe 面板、握手、宿主节点导航、Anchor 上下文、版本稳定快照、sidecar 加载与保存
+    ├── mpeProtocol.ts        # mpe-embed 协议校验与类型、JSONC 写回、`.mpe.json` 合并/拆分、sidecar 判定、加载授权
     ├── root.ts               # RootService — 资源根目录扫描
     ├── interface.ts          # InterfaceService — 接口包管理
     ├── launch.ts             # LaunchService — 任务启动编排
@@ -74,6 +74,12 @@ src/
         ├── promise.ts        # makePromise() 延迟 Promise
         └── color.js/.d.ts    # HSV→RGB 转换
 ```
+
+## MPE iframe 协议
+
+MSE 作为 MPE iframe 宿主使用 `mpe-embed` v1.4.0，1.x 消息仍按主版本兼容。`mpe:init` 通过 `hostNodeNavigation: true` 声明外部节点由宿主导航；MPE 发送带 `requestId` 的 `mpe:navigateNodeRequest` 后，MSE 复用 `InterfaceBundle.topLayer.getTask()` 查找定义，打开非预览 JSON 标签和对应 MPE 面板，再返回 `mpe:navigateNodeResult`。目标面板只在匹配的 `mpe:loadResult` 成功后接收 `mpe:selectNode` 与 `mpe:focusNode`。
+
+`mpe:loadPipeline` 同时携带来自 `InterfaceBundle.topLayer.getAnchorList()` 的 `anchorDefinitions`，每项包含 Anchor 名、声明节点、文件名、相对路径和当前文件标记。这些数据只用于 iframe 内展示定义上下文，Anchor 不走宿主导航。Anchor 索引采集失败时降级为空列表，不阻断 Pipeline 本身加载。
 
 ## 服务类层次
 

--- a/docs/maa-locale/models/README.md
+++ b/docs/maa-locale/models/README.md
@@ -46,6 +46,7 @@ t('maa.pi.error.cannot-find-task', taskName)
 - `maa.crop.*` — 裁剪工具
 - `maa.screencap.*` — 快速截图命令
 - `maa.shortcut.*` — 全局快捷键目标和运行控制提示
+- `maa.mpe.*` — MaaPipelineEditor 集成与节点导航
 - `maa.eval.*` — 表达式求值
 
 ## 版本语义

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -2,12 +2,14 @@ import { randomUUID } from 'node:crypto'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 
-import type { AbsolutePath } from '@nekosu/maa-pipeline-manager'
+import type { AbsolutePath, TaskName } from '@nekosu/maa-pipeline-manager'
 
 import { isMaaAssistantArknights } from '../utils/fs'
 import { logger } from '../utils/logger'
 import { BaseService } from './context'
+import { convertRange } from './language/utils'
 import {
+  type MpeAnchorDefinition,
   type MpeConfig,
   type MpeLoadAuth,
   type MpeProtocolMessage,
@@ -31,11 +33,16 @@ import {
   stringifyMpeConfig,
   updatePipelineText
 } from './mpeProtocol'
-import { interfaceService } from './registry'
+import { interfaceService, rootService } from './registry'
 
 const repositoryUrl = 'https://github.com/neko-para/maa-support-extension'
 const defaultUrl = 'https://mpe.codax.site/stable/'
 const snapshotRetries = 3
+
+type MpeNavigationResult = {
+  success: boolean
+  message: string
+}
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -89,7 +96,7 @@ export class MpeService extends BaseService {
     super.dispose()
   }
 
-  async open(uri: vscode.Uri) {
+  async open(uri: vscode.Uri, focusNode?: string) {
     const doc = await vscode.workspace.openTextDocument(uri)
     if (!this.supported(doc)) {
       vscode.window.showErrorMessage(
@@ -101,13 +108,60 @@ export class MpeService extends BaseService {
     const existing = this.panels.get(key)
     if (existing) {
       existing.panel.reveal()
+      if (focusNode) existing.focusNode(focusNode)
       return true
     }
-    const panel = new MpePanel(doc)
+    const panel = new MpePanel(doc, nodeName => this.navigateNode(nodeName))
     this.panels.set(key, panel)
     panel.onDispose = () => this.panels.delete(key)
+    if (focusNode) panel.focusNode(focusNode)
     await panel.start()
     return true
+  }
+
+  private async navigateNode(nodeName: string): Promise<MpeNavigationResult> {
+    try {
+      const intBundle = interfaceService.interfaceBundle
+      if (!intBundle) {
+        return { success: false, message: '当前没有可用的 Pipeline 资源' }
+      }
+
+      await intBundle.flush()
+      const targets = intBundle.topLayer.getTask(nodeName as TaskName).flatMap(({ infos }) => infos)
+      if (targets.length === 0) {
+        return { success: false, message: `未找到节点: ${nodeName}` }
+      }
+
+      let target = targets[0]
+      if (targets.length > 1) {
+        const selected = await vscode.window.showQuickPick(
+          targets.map(item => ({
+            label: rootService.relativeToRoot(item.file),
+            item
+          })),
+          { title: `选择节点 ${nodeName} 的定义` }
+        )
+        if (!selected) {
+          return { success: false, message: '已取消节点跳转' }
+        }
+        target = selected.item
+      }
+
+      const document = await vscode.workspace.openTextDocument(target.file)
+      const editor = await vscode.window.showTextDocument(document, { preview: false })
+      const range = convertRange(document, target.prop)
+      const selection = new vscode.Selection(range.start, range.end)
+      editor.selection = selection
+      editor.revealRange(selection)
+
+      if (!(await this.open(document.uri, nodeName))) {
+        return { success: false, message: `无法在 MPE 中打开节点: ${nodeName}` }
+      }
+      return { success: true, message: `已打开节点: ${nodeName}` }
+    } catch (error) {
+      logger.error(`Failed to navigate to MPE node ${nodeName}: ${String(error)}`)
+      return { success: false, message: `节点跳转失败: ${nodeName}` }
+    }
   }
 
   supported(doc: vscode.TextDocument) {
@@ -125,11 +179,14 @@ export class MpeService extends BaseService {
 class MpePanel implements vscode.Disposable {
   readonly panel: vscode.WebviewPanel
   private ready = false
+  private canvasLoaded = false
   private loadAuth: MpeLoadAuth = 'idle'
   private disposed = false
   private queue: MpeProtocolMessage[] = []
   private pendingSave?: { requestId: string; documentVersion: number; force: boolean }
   private loadedDocumentVersion?: number
+  private activeLoadRequestId?: string
+  private pendingFocusNode?: string
   private separatedConfigUri?: vscode.Uri
   private saveTimeout?: ReturnType<typeof setTimeout>
   private requestCounter = 0
@@ -137,7 +194,10 @@ class MpePanel implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = []
   onDispose = () => {}
 
-  constructor(private readonly document: vscode.TextDocument) {
+  constructor(
+    private readonly document: vscode.TextDocument,
+    private readonly navigateNode: (nodeName: string) => Promise<MpeNavigationResult>
+  ) {
     this.panel = vscode.window.createWebviewPanel(
       'maa.mpe',
       `MPE: ${path.basename(document.fileName)}`,
@@ -204,7 +264,8 @@ class MpePanel implements vscode.Disposable {
           allowUndoRedo: true,
           allowAutoLayout: true,
           allowSearch: true,
-          allowCustomTemplate: true
+          allowCustomTemplate: true,
+          hostNodeNavigation: true
         },
         ui: { hideHeader: false, hideToolbar: false, hiddenPanels: [] },
         host: { id: 'mse', name: 'MSE', repositoryUrl }
@@ -222,7 +283,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
   private receive(value: unknown) {
     if (asRecord(value)?.builtin === 'mpe-host-ready') {
       this.ready = false
+      this.canvasLoaded = false
       this.loadAuth = beginMpeLoad()
+      this.activeLoadRequestId = undefined
       this.pendingSave = undefined
       this.loadSeq += 1
       if (this.saveTimeout) clearTimeout(this.saveTimeout)
@@ -245,6 +308,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       case 'mpe:reloadRequest':
         void this.load(message.requestId)
         break
+      case 'mpe:loadResult':
+        this.finishLoad(message)
+        break
       case 'mpe:saveRequest':
         this.requestSave(message)
         break
@@ -254,14 +320,22 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       case 'mpe:openExternalRequest':
         void this.openExternal(asRecord(message.payload)?.url)
         break
+      case 'mpe:navigateNodeRequest':
+        void this.requestNodeNavigation(message)
+        break
     }
   }
 
   private async load(requestId?: string) {
     const seq = ++this.loadSeq
+    this.activeLoadRequestId = requestId
+    this.canvasLoaded = false
     this.loadAuth = beginMpeLoad()
     try {
-      const snapshot = await this.pipelineSnapshot()
+      const [snapshot, anchorDefinitions] = await Promise.all([
+        this.pipelineSnapshot(),
+        this.anchorDefinitions()
+      ])
       if (this.disposed || seq !== this.loadSeq) {
         return
       }
@@ -272,12 +346,17 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         version: mpeProtocolVersion,
         type: 'mpe:loadPipeline',
         requestId,
-        payload: { fileName: path.basename(this.document.fileName), data: snapshot.data }
+        payload: {
+          fileName: path.basename(this.document.fileName),
+          data: snapshot.data,
+          anchorDefinitions
+        }
       })
     } catch (error) {
       if (this.disposed || seq !== this.loadSeq) {
         return
       }
+      this.activeLoadRequestId = undefined
       this.loadAuth = finishMpeLoad(false)
       this.send({
         protocol: mpeProtocol,
@@ -287,6 +366,78 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         payload: { code: errorCode(error, 'invalid_pipeline'), message: String(error) }
       })
     }
+  }
+
+  private finishLoad(message: MpeProtocolMessage) {
+    if (!this.activeLoadRequestId || message.requestId !== this.activeLoadRequestId) return
+    this.activeLoadRequestId = undefined
+    this.canvasLoaded = asRecord(message.payload)?.success === true
+    if (this.canvasLoaded) this.flushPendingFocus()
+  }
+
+  private async anchorDefinitions(): Promise<MpeAnchorDefinition[]> {
+    const intBundle = interfaceService.interfaceBundle
+    if (!intBundle) return []
+
+    try {
+      await intBundle.flush()
+      const currentFile = this.document.uri.fsPath
+      return intBundle.topLayer.getAnchorList().map(([anchorName, decl]) => {
+        // getAnchorList exposes the anchor variant, but returns the complete indexed declaration.
+        const file = (decl as typeof decl & { file: AbsolutePath }).file
+        return {
+          anchorName,
+          nodeName: decl.belong,
+          fileName: path.basename(file),
+          relativePath: rootService.relativeToRoot(file),
+          isCurrentFile: file === currentFile
+        }
+      })
+    } catch (error) {
+      logger.warn(`Failed to collect MPE anchor definitions: ${String(error)}`)
+      return []
+    }
+  }
+
+  private async requestNodeNavigation(message: MpeProtocolMessage) {
+    const requestId = message.requestId
+    if (!requestId) return
+
+    const value = asRecord(message.payload)?.nodeName
+    const nodeName = typeof value === 'string' && value.trim().length > 0 ? value : undefined
+    const result = nodeName
+      ? await this.navigateNode(nodeName)
+      : { success: false, message: '节点名为空' }
+    this.send({
+      protocol: mpeProtocol,
+      version: mpeProtocolVersion,
+      type: 'mpe:navigateNodeResult',
+      requestId,
+      payload: { ...result, nodeName: nodeName ?? '' }
+    })
+  }
+
+  focusNode(nodeName: string) {
+    this.pendingFocusNode = nodeName
+    if (this.canvasLoaded) this.flushPendingFocus()
+  }
+
+  private flushPendingFocus() {
+    const nodeName = this.pendingFocusNode
+    if (!nodeName) return
+    this.pendingFocusNode = undefined
+    this.send({
+      protocol: mpeProtocol,
+      version: mpeProtocolVersion,
+      type: 'mpe:selectNode',
+      payload: { nodeId: nodeName }
+    })
+    this.send({
+      protocol: mpeProtocol,
+      version: mpeProtocolVersion,
+      type: 'mpe:focusNode',
+      payload: { nodeId: nodeName }
+    })
   }
 
   private sidecarUri() {

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 
+import { t } from '@nekosu/maa-locale'
 import type { AbsolutePath, TaskName } from '@nekosu/maa-pipeline-manager'
 
 import { isMaaAssistantArknights } from '../utils/fs'
@@ -123,7 +124,7 @@ export class MpeService extends BaseService {
     try {
       const intBundle = interfaceService.interfaceBundle
       if (!intBundle) {
-        return { success: false, message: '当前没有可用的 Pipeline 资源' }
+        return { success: false, message: t('maa.mpe.error.no-resource') }
       }
 
       await intBundle.flush(true)
@@ -131,20 +132,24 @@ export class MpeService extends BaseService {
         .getTask(nodeName as TaskName, false)
         .flatMap(({ infos }) => infos)
       if (targets.length === 0) {
-        return { success: false, message: `未找到节点: ${nodeName}` }
+        return { success: false, message: t('maa.mpe.error.node-not-found', nodeName) }
       }
 
       let target = targets[0]
       if (targets.length > 1) {
+        const labels = targets.map(item => rootService.relativeToRoot(item.file))
+        const counts = new Map<string, number>()
+        for (const label of labels) counts.set(label, (counts.get(label) ?? 0) + 1)
         const selected = await vscode.window.showQuickPick(
-          targets.map(item => ({
-            label: rootService.relativeToRoot(item.file),
+          targets.map((item, index) => ({
+            label:
+              counts.get(labels[index])! > 1 ? `${labels[index]} (${index + 1})` : labels[index],
             item
           })),
-          { title: `选择节点 ${nodeName} 的定义` }
+          { title: t('maa.mpe.title.select-node-definition', nodeName) }
         )
         if (!selected) {
-          return { success: false, message: '已取消节点跳转' }
+          return { success: false, message: t('maa.mpe.info.navigation-cancelled') }
         }
         target = selected.item
       }
@@ -157,12 +162,12 @@ export class MpeService extends BaseService {
       editor.revealRange(selection)
 
       if (!(await this.open(document.uri, nodeName))) {
-        return { success: false, message: `无法在 MPE 中打开节点: ${nodeName}` }
+        return { success: false, message: t('maa.mpe.error.open-node-failed', nodeName) }
       }
-      return { success: true, message: `已打开节点: ${nodeName}` }
+      return { success: true, message: t('maa.mpe.info.node-opened', nodeName) }
     } catch (error) {
       logger.error(`Failed to navigate to MPE node ${nodeName}: ${String(error)}`)
-      return { success: false, message: `节点跳转失败: ${nodeName}` }
+      return { success: false, message: t('maa.mpe.error.navigation-failed', nodeName) }
     }
   }
 

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -126,8 +126,10 @@ export class MpeService extends BaseService {
         return { success: false, message: '当前没有可用的 Pipeline 资源' }
       }
 
-      await intBundle.flush()
-      const targets = intBundle.topLayer.getTask(nodeName as TaskName).flatMap(({ infos }) => infos)
+      await intBundle.flush(true)
+      const targets = intBundle.topLayer
+        .getTask(nodeName as TaskName, false)
+        .flatMap(({ infos }) => infos)
       if (targets.length === 0) {
         return { success: false, message: `未找到节点: ${nodeName}` }
       }
@@ -380,10 +382,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
     if (!intBundle) return []
 
     try {
-      await intBundle.flush()
+      await intBundle.flush(true)
       const currentFile = this.document.uri.fsPath
       return intBundle.topLayer.getAnchorList().map(([anchorName, decl]) => {
-        // getAnchorList exposes the anchor variant, but returns the complete indexed declaration.
         const file = (decl as typeof decl & { file: AbsolutePath }).file
         return {
           anchorName,

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -45,7 +45,15 @@ function parseJsonObject(text: string, label: string) {
 }
 
 export const mpeProtocol = 'mpe-embed'
-export const mpeProtocolVersion = '1.3.0'
+export const mpeProtocolVersion = '1.4.0'
+
+export type MpeAnchorDefinition = {
+  anchorName: string
+  nodeName: string
+  fileName: string
+  relativePath: string
+  isCurrentFile: boolean
+}
 
 export type MpeProtocolMessage = {
   protocol: typeof mpeProtocol

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -76,6 +76,37 @@ test('MPE host identifies itself with the MSE product name', () => {
   assert.match(source, /host: \{ id: 'mse', name: 'MSE', repositoryUrl \}/)
 })
 
+test('MPE host delegates embedded node navigation to the existing task index', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.equal(mpeProtocolVersion, '1.4.0')
+  assert.match(source, /hostNodeNavigation: true/)
+  assert.match(source, /case 'mpe:navigateNodeRequest':/)
+  assert.match(source, /topLayer\s*\.getTask\(nodeName as TaskName\)/)
+  assert.match(source, /vscode\.window\.showTextDocument\(document, \{ preview: false \}\)/)
+  assert.match(source, /this\.open\(document\.uri, nodeName\)/)
+  assert.match(source, /type: 'mpe:navigateNodeResult'/)
+})
+
+test('MPE host supplies anchor definitions from the existing anchor index', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /topLayer\.getAnchorList\(\)/)
+  assert.match(source, /nodeName: decl\.belong/)
+  assert.match(source, /anchorDefinitions/)
+  assert.match(source, /isCurrentFile:/)
+})
+
+test('MPE host focuses a requested node only after the target canvas loads', () => {
+  const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /case 'mpe:loadResult':/)
+  assert.match(source, /type: 'mpe:selectNode'/)
+  assert.match(source, /type: 'mpe:focusNode'/)
+  assert.match(source, /pendingFocusNode/)
+  assert.match(source, /canvasLoaded/)
+})
+
 test('rejects malformed and non-object pipeline content', () => {
   assert.throws(() => parsePipeline('{ invalid }'), /parse failed/)
   assert.throws(() => parsePipeline('[]'), /JSON object/)

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -82,7 +82,7 @@ test('MPE host delegates embedded node navigation to the existing task index', (
   assert.equal(mpeProtocolVersion, '1.4.0')
   assert.match(source, /hostNodeNavigation: true/)
   assert.match(source, /case 'mpe:navigateNodeRequest':/)
-  assert.match(source, /topLayer\s*\.getTask\(nodeName as TaskName\)/)
+  assert.match(source, /topLayer\s*\.getTask\(nodeName as TaskName, false\)/)
   assert.match(source, /vscode\.window\.showTextDocument\(document, \{ preview: false \}\)/)
   assert.match(source, /this\.open\(document\.uri, nodeName\)/)
   assert.match(source, /type: 'mpe:navigateNodeResult'/)

--- a/pkgs/maa-locale/src/locale.en.ts
+++ b/pkgs/maa-locale/src/locale.en.ts
@@ -41,6 +41,14 @@ export default {
   'maa.pi.error.generate-runtime-failed': 'Generate runtime failed: {0}',
   'maa.pi.warning.require-admin': 'Controller require admin privileges',
 
+  'maa.mpe.title.select-node-definition': 'Select definition of node {0}',
+  'maa.mpe.error.no-resource': 'No Pipeline resource is available',
+  'maa.mpe.error.node-not-found': 'Cannot find node {0}',
+  'maa.mpe.error.open-node-failed': 'Cannot open node {0} in MPE',
+  'maa.mpe.error.navigation-failed': 'Failed to navigate to node {0}',
+  'maa.mpe.info.navigation-cancelled': 'Node navigation cancelled',
+  'maa.mpe.info.node-opened': 'Opened node {0}',
+
   'maa.debug.init-controller-failed': 'Init controller failed',
   'maa.debug.init-resource-failed': 'Init resource failed',
   'maa.debug.init-instance-failed': 'Init instance failed',

--- a/pkgs/maa-locale/src/locale.zh-cn.ts
+++ b/pkgs/maa-locale/src/locale.zh-cn.ts
@@ -39,6 +39,14 @@ export default {
   'maa.pi.error.generate-runtime-failed': '生成配置失败: {0}',
   'maa.pi.warning.require-admin': '控制器需要管理员权限',
 
+  'maa.mpe.title.select-node-definition': '选择节点 {0} 的定义',
+  'maa.mpe.error.no-resource': '当前没有可用的 Pipeline 资源',
+  'maa.mpe.error.node-not-found': '未找到节点: {0}',
+  'maa.mpe.error.open-node-failed': '无法在 MPE 中打开节点: {0}',
+  'maa.mpe.error.navigation-failed': '节点跳转失败: {0}',
+  'maa.mpe.info.navigation-cancelled': '已取消节点跳转',
+  'maa.mpe.info.node-opened': '已打开节点: {0}',
+
   'maa.debug.init-controller-failed': '初始化控制器失败',
   'maa.debug.init-resource-failed': '初始化资源失败',
   'maa.debug.init-instance-failed': '初始化实例失败',


### PR DESCRIPTION
## Summary

修复 MPE iframe 嵌入模式下无法正确处理跨文件节点跳转的问题，并补充 Anchor 定义上下文。

## Changes

- 通过 `hostNodeNavigation` 声明 External 节点导航由 MSE 宿主处理
- 复用现有 Pipeline 索引查找目标节点
- 存在多个同名定义时提供目标文件选择
- 跳转时同时打开并定位目标 JSON 文档以及对应 MPE 面板
- 等待目标画布加载成功后再选中并聚焦节点
- 复用现有 Anchor 索引，将定义文件、所属节点等上下文传给 MPE
- iframe 模式下禁用 Anchor 跳转，仅保留定义位置展示
- Anchor 索引读取失败时降级为空列表，不影响 Pipeline 加载
- 同步更新 MPE 集成相关文档和测试

## Behavior

External 节点跳转现在由 MSE 在当前资源中解析：

1. 刷新并查询现有 Pipeline 索引
2. 必要时选择同名节点的具体定义
3. 以非预览标签打开目标 JSON 并定位定义
4. 打开或复用目标文件对应的 MPE 面板
5. 在目标画布加载成功后选中并聚焦节点

Anchor 在 iframe 模式下不提供跳转，但仍会列出当前资源中定义该 Anchor 的文件和节点。
