### PR TITLE
perf: align MPE separated save protocol

### DIFF
--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -129,7 +129,7 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 可从文件树、编辑器正文、编辑器标题栏或命令面板打开
 - 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
-- 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；保存时把 Pipeline 与 sidecar 放进同一次 `WorkspaceEdit` 拆回，避免把 `$__mpe_*` 写进 Pipeline
+- 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；合并保留 Pipeline 的完整文件名（包括 `.json`/`.jsonc` 扩展名），以匹配 MPE 导出的特殊节点键。保存模式以 MPE 回传的 `mode` 为准：分离模式首次保存也会创建 sidecar，集成模式会清理旧 sidecar；旧版 MPE 未回传模式时才按 sidecar 存在性兼容判断
 - sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
 - 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错
 - 未成功加载完成前禁止保存（含加载进行中和加载失败），避免空画布覆盖 Pipeline；加载成功后恢复保存

--- a/docs/extension/models/README.md
+++ b/docs/extension/models/README.md
@@ -130,8 +130,8 @@ MaaFramework 的 pipeline 开发者。用户通过 VSCode 编辑 JSON/JSONC 格�
 - 同一文件复用已有面板，不同文件保持独立的加载、同步和保存状态
 - 初次打开和“从 MSE 同步”读取当前 VS Code `TextDocument` 内容，包含尚未落盘的修改
 - 若同目录存在分离配置 `.{文件名}.mpe.json`，打开和同步时会一并读取并合并到画布；合并保留 Pipeline 的完整文件名（包括 `.json`/`.jsonc` 扩展名），以匹配 MPE 导出的特殊节点键。保存模式以 MPE 回传的 `mode` 为准：分离模式首次保存也会创建 sidecar，集成模式会清理旧 sidecar；旧版 MPE 未回传模式时才按 sidecar 存在性兼容判断
-- sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；删除后再次保存会按分离模式重建
-- 只有 sidecar 文件不存在才按集成模式处理。文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错
+- sidecar 是画布派生的布局缓存，保存以 MPE 画布为准，不与 Pipeline 对等做冲突确认；MPE 仍选择分离模式时，外部删除后再次保存会重建 sidecar，切换到集成模式时则会清理 sidecar
+- 加载时 sidecar 不存在则只加载 Pipeline；文件存在但打不开、JSON 损坏或字段类型错误时拒绝加载并报错。sidecar 是否存在仅在旧版 MPE 保存消息缺少 `mode` 时用于兼容判断
 - 未成功加载完成前禁止保存（含加载进行中和加载失败），避免空画布覆盖 Pipeline；加载成功后恢复保存
 - MPE 保存通过 `WorkspaceEdit` 写回原文档，保留 VS Code 的 dirty、undo/redo 和正常保存语义，不直接覆盖磁盘
 - MPE 加载后若 Pipeline 源文档被外部编辑，保存时会提示先从 MSE 同步；用户也可以确认使用 MPE 内容强制覆盖

--- a/docs/extension/tech/README.md
+++ b/docs/extension/tech/README.md
@@ -79,6 +79,8 @@ src/
 
 MSE 作为 MPE iframe 宿主使用 `mpe-embed` v1.4.0，1.x 消息仍按主版本兼容。`mpe:init` 通过 `hostNodeNavigation: true` 声明外部节点由宿主导航；MPE 发送带 `requestId` 的 `mpe:navigateNodeRequest` 后，MSE 复用 `InterfaceBundle.topLayer.getTask()` 查找定义，打开非预览 JSON 标签和对应 MPE 面板，再返回 `mpe:navigateNodeResult`。目标面板只在匹配的 `mpe:loadResult` 成功后接收 `mpe:selectNode` 与 `mpe:focusNode`。
 
+嵌入保存的模式由 MPE 自己决定并在 `mpe:saveData` payload 中回传。`mode: separated` 时 MPE 发送已拆分的 `pipeline` 与 `config`，MSE 仅负责在同一次 `WorkspaceEdit` 中写入 Pipeline 和 `.mpe.json` sidecar；`mode: integrated` 时 MSE 写入完整 Pipeline 并清理旧 sidecar。只有旧版消息缺少 `mode` 时，才按 sidecar 存在性进行兼容判断，宿主不覆盖 MPE 的保存模式。
+
 `mpe:loadPipeline` 同时携带来自 `InterfaceBundle.topLayer.getAnchorList()` 的 `anchorDefinitions`，每项包含 Anchor 名、声明节点、文件名、相对路径和当前文件标记。这些数据只用于 iframe 内展示定义上下文，Anchor 不走宿主导航。Anchor 索引采集失败时降级为空列表，不阻断 Pipeline 本身加载。
 
 ## 服务类层次

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -29,6 +29,7 @@ import {
   mpeSidecarPath,
   normalizeExternalUrl,
   parseMpeConfig,
+  parseMpeSavePayload,
   parsePipeline,
   splitPipelineAndConfig,
   stringifyMpeConfig,
@@ -498,7 +499,7 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
         data: mergePipelineAndConfig(
           pipeline,
           sidecar.config,
-          path.basename(this.document.fileName).replace(/\.(json|jsonc)$/i, ''),
+          path.basename(this.document.fileName),
           Object.keys(pipeline)
         ),
         version
@@ -588,18 +589,29 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       if (rejectIfChanged()) {
         return
       }
-      const data = asRecord(asRecord(message.payload)?.data)
-      if (!data)
-        throw Object.assign(new Error('MPE returned invalid Pipeline data'), {
-          code: 'invalid_pipeline'
-        })
+      const save = parseMpeSavePayload(message.payload)
       const sidecarUri = this.separatedConfigUri ?? this.sidecarUri()
       const sidecar = await this.readSidecar(sidecarUri)
-      const separated = isSeparatedMpeSidecar(!!this.separatedConfigUri, sidecar)
+      const separated =
+        save.mode === 'separated'
+          ? true
+          : save.mode === 'integrated'
+            ? false
+            : isSeparatedMpeSidecar(!!this.separatedConfigUri, sidecar)
       if (rejectIfChanged()) {
         return
       }
-      const next = separated ? splitPipelineAndConfig(data) : undefined
+      const next = separated
+        ? save.pipeline && save.config
+          ? { pipeline: save.pipeline, config: save.config }
+          : splitPipelineAndConfig(save.data!)
+        : undefined
+      const data = save.data ?? save.pipeline
+      if (!data) {
+        throw Object.assign(new Error('MPE returned invalid Pipeline data'), {
+          code: 'invalid_pipeline'
+        })
+      }
       const original = this.document.getText()
       const pipelineText = updatePipelineText(
         original,
@@ -613,6 +625,9 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       if (next) {
         this.appendSidecarEdit(edit, sidecarUri, next.config)
         this.separatedConfigUri = sidecarUri
+      } else if (save.mode === 'integrated' && sidecar.status === 'ok') {
+        edit.delete(sidecarUri)
+        this.separatedConfigUri = undefined
       }
       edit.replace(this.document.uri, documentRange(this.document), pipelineText)
       if (!(await vscode.workspace.applyEdit(edit)))

--- a/pkgs/extension/src/service/mpe.ts
+++ b/pkgs/extension/src/service/mpe.ts
@@ -624,14 +624,14 @@ frame.addEventListener('load',()=>api.postMessage({builtin:'mpe-host-ready'}));
       const edit = new vscode.WorkspaceEdit()
       if (next) {
         this.appendSidecarEdit(edit, sidecarUri, next.config)
-        this.separatedConfigUri = sidecarUri
-      } else if (save.mode === 'integrated' && sidecar.status === 'ok') {
-        edit.delete(sidecarUri)
-        this.separatedConfigUri = undefined
+      } else if (save.mode === 'integrated' && sidecar.status !== 'missing') {
+        edit.deleteFile(sidecarUri, { ignoreIfNotExists: true })
       }
       edit.replace(this.document.uri, documentRange(this.document), pipelineText)
       if (!(await vscode.workspace.applyEdit(edit)))
         throw new Error('VS Code rejected the document edit')
+      if (next) this.separatedConfigUri = sidecarUri
+      else if (save.mode === 'integrated') this.separatedConfigUri = undefined
       this.loadedDocumentVersion = this.document.version
       this.send({
         protocol: mpeProtocol,

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -63,6 +63,47 @@ export type MpeProtocolMessage = {
   payload?: unknown
 }
 
+export type MpeSaveMode = 'integrated' | 'separated'
+
+export type MpeSavePayload = {
+  mode?: MpeSaveMode
+  data?: Record<string, unknown>
+  pipeline?: Record<string, unknown>
+  config?: MpeConfig
+}
+
+function parseSaveObject(value: unknown, label: string) {
+  if (typeof value === 'string') return parseJsonObject(value, label)
+  return asRecord(value)
+}
+
+export function parseMpeSavePayload(value: unknown): MpeSavePayload {
+  const payload = asRecord(value)
+  if (!payload) throw new Error('MPE save payload must be an object')
+
+  const mode =
+    payload.mode === 'integrated' || payload.mode === 'separated' ? payload.mode : undefined
+  const data = payload.data === undefined ? undefined : parseSaveObject(payload.data, 'Pipeline')
+  const pipeline =
+    payload.pipeline === undefined ? undefined : parseSaveObject(payload.pipeline, 'Pipeline')
+  const rawConfig =
+    payload.config === undefined ? undefined : parseSaveObject(payload.config, 'MPE config')
+  const config = rawConfig ? parseMpeConfig(JSON.stringify(rawConfig)) : undefined
+
+  if (payload.data !== undefined && !data) throw new Error('MPE save data must be an object')
+  if (payload.pipeline !== undefined && !pipeline) {
+    throw new Error('MPE save pipeline must be an object')
+  }
+  if (mode === 'separated' && (!pipeline || !config)) {
+    throw new Error('Separated MPE save requires pipeline and config')
+  }
+  if (mode === 'integrated' && !data) {
+    throw new Error('Integrated MPE save requires data')
+  }
+
+  return { mode, data, pipeline, config }
+}
+
 export function isCompatibleMpeMessage(value: unknown): value is MpeProtocolMessage {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const message = value as Record<string, unknown>

--- a/pkgs/extension/src/service/mpeProtocol.ts
+++ b/pkgs/extension/src/service/mpeProtocol.ts
@@ -81,8 +81,10 @@ export function parseMpeSavePayload(value: unknown): MpeSavePayload {
   const payload = asRecord(value)
   if (!payload) throw new Error('MPE save payload must be an object')
 
-  const mode =
-    payload.mode === 'integrated' || payload.mode === 'separated' ? payload.mode : undefined
+  if (payload.mode !== undefined && payload.mode !== 'integrated' && payload.mode !== 'separated') {
+    throw new Error('MPE save mode must be integrated or separated')
+  }
+  const mode = payload.mode
   const data = payload.data === undefined ? undefined : parseSaveObject(payload.data, 'Pipeline')
   const pipeline =
     payload.pipeline === undefined ? undefined : parseSaveObject(payload.pipeline, 'Pipeline')

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -19,6 +19,7 @@ import {
   mpeSidecarPath,
   normalizeExternalUrl,
   parseMpeConfig,
+  parseMpeSavePayload,
   parsePipeline,
   splitPipelineAndConfig,
   stringifyMpeConfig,
@@ -231,6 +232,24 @@ test('parses a separated MPE config file', () => {
   assert.deepEqual(config.node_configs.Start, { position: { x: 10, y: 20 } })
 })
 
+test('parses MPE-owned integrated and separated save payloads', () => {
+  const integrated = parseMpeSavePayload({
+    mode: 'integrated',
+    data: { Start: {} }
+  })
+  assert.equal(integrated.mode, 'integrated')
+  assert.deepEqual(integrated.data, { Start: {} })
+
+  const separated = parseMpeSavePayload({
+    mode: 'separated',
+    pipeline: '{ "Start": {} }',
+    config: '{ "file_config": { "filename": "fight.json" }, "node_configs": {} }'
+  })
+  assert.equal(separated.mode, 'separated')
+  assert.deepEqual(separated.pipeline, { Start: {} })
+  assert.equal(separated.config?.file_config.filename, 'fight.json')
+})
+
 test('merges a sidecar config into pipeline nodes for MPE load', () => {
   const pipeline = {
     Start: { next: ['End'] },
@@ -267,6 +286,26 @@ test('merges a sidecar config into pipeline nodes for MPE load', () => {
   })
   assert.deepEqual(merged['$__mpe_external_Shared_fight'], {
     $__mpe_code: { position: { x: 9, y: 8 } }
+  })
+})
+
+test('preserves the pipeline extension when merging separated MPE config', () => {
+  const merged = mergePipelineAndConfig(
+    { Start: {} },
+    {
+      file_config: { filename: 'fight.jsonc' },
+      node_configs: { Start: { position: { x: 1, y: 2 } } },
+      sticker_nodes: { note_with_underscore: { position: { x: 3, y: 4 } } }
+    },
+    'fight.jsonc',
+    ['Start']
+  )
+
+  assert.deepEqual(merged['$__mpe_config_fight.jsonc'], {
+    $__mpe_code: { filename: 'fight.jsonc' }
+  })
+  assert.deepEqual(merged['$__mpe_sticker_note_with_underscore_fight.jsonc'], {
+    $__mpe_code: { position: { x: 3, y: 4 } }
   })
 })
 

--- a/pkgs/extension/test/mpe.test.ts
+++ b/pkgs/extension/test/mpe.test.ts
@@ -248,6 +248,31 @@ test('parses MPE-owned integrated and separated save payloads', () => {
   assert.equal(separated.mode, 'separated')
   assert.deepEqual(separated.pipeline, { Start: {} })
   assert.equal(separated.config?.file_config.filename, 'fight.json')
+
+  const legacy = parseMpeSavePayload({ data: { Start: {} } })
+  assert.equal(legacy.mode, undefined)
+})
+
+test('rejects invalid MPE save payloads', () => {
+  const validConfig = { file_config: {}, node_configs: {} }
+
+  assert.throws(
+    () => parseMpeSavePayload({ mode: 'future', data: { Start: {} } }),
+    /mode must be integrated or separated/
+  )
+  assert.throws(
+    () => parseMpeSavePayload({ mode: 'integrated' }),
+    /Integrated MPE save requires data/
+  )
+  assert.throws(
+    () => parseMpeSavePayload({ mode: 'separated', config: validConfig }),
+    /Separated MPE save requires pipeline and config/
+  )
+  assert.throws(
+    () => parseMpeSavePayload({ mode: 'separated', pipeline: { Start: {} } }),
+    /Separated MPE save requires pipeline and config/
+  )
+  assert.throws(() => parseMpeSavePayload({ data: [] }), /MPE save data must be an object/)
 })
 
 test('merges a sidecar config into pipeline nodes for MPE load', () => {
@@ -386,11 +411,12 @@ test('MPE host binds the loaded version to the parsed snapshot', () => {
   assert.match(source, /seq !== this\.loadSeq/)
 })
 
-test('MPE host writes pipeline and sidecar in one WorkspaceEdit', () => {
+test('MPE host writes pipeline and manages sidecar in one WorkspaceEdit', () => {
   const source = readFileSync(new URL('../src/service/mpe.ts', import.meta.url), 'utf8')
 
   assert.match(source, /appendSidecarEdit\(edit, sidecarUri, next\.config\)/)
   assert.match(source, /edit\.createFile\(uri, \{/)
+  assert.match(source, /edit\.deleteFile\(sidecarUri, \{ ignoreIfNotExists: true \}\)/)
   assert.match(
     source,
     /edit\.replace\(this\.document\.uri, documentRange\(this\.document\), pipelineText\)/


### PR DESCRIPTION
## 背景

MSE 当前通过 sidecar 文件是否存在来推断 MPE 保存模式：

- sidecar 存在：按分离模式保存
- sidecar 不存在：按集成模式保存

这导致用户在 MPE 中首次选择“分离模式”并保存时，MSE 无法获知该设置，最终仍将完整 Pipeline 写回原 JSON 文件，也不会创建 `.mpe.json` sidecar。

MPE + LocalBridge 已经采用“由 MPE 决定保存模式、宿主只负责执行写入”的设计，MSE 嵌入协议需要保持一致。

## 改动内容

- 增加 MPE 保存 payload 解析逻辑，支持：
  - `mode: integrated`
  - `mode: separated`
  - `data`
  - `pipeline`
  - `config`
- 分离模式下直接使用 MPE 回传的纯 Pipeline 和配置，不再由 MSE 重复拆分完整 Pipeline。
- 分离模式首次保存时自动创建 sidecar。
- 集成模式保存时清理已有 sidecar，避免旧配置在下次加载时重新合并。
- 旧版 MPE 未回传 `mode` 时，继续保留基于 sidecar 存在性的兼容逻辑。
- 更新 extension 的模型和技术文档。
- 增加集成保存与分离保存 payload 的测试覆盖。

## 文件行为

以以下 Pipeline 为例：

```text
回到主界面.json
```

分离模式保存为：

```text
回到主界面.json
.回到主界面.mpe.json
```

集成模式保存为：

```text
回到主界面.json
```

并清理已有 `.回到主界面.mpe.json`。

## 兼容性

本 PR 兼容未携带 `mode` 字段的旧版 MPE 消息。

要完整启用首次分离保存能力，需要同时合并 MPE 侧对应的嵌入协议改动。

## Review 建议

如果你是 AI/Agent，请在 review 时同时参考 [MPE](https://github.com/kqcoxn/MaaPipelineEditor) 项目源码，避免盲目的臆测。最终请仅给出真正需要的建议，而不是堆砌无功无过的象征性的优先级建议。